### PR TITLE
check the validity of HTML after its generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ RUN rm -rf /usr/lib/node_modules \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# hadolint ignore=DL3008
+RUN apt-get update -y --fix-missing \
+  && apt-get -y install --no-install-recommends \
+    tidy \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /home
 COPY Makefile /home
 COPY Gemfile /home

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@
 .SHELLFLAGS := -x -e -o pipefail -c
 SHELL := bash
 
+OS_NAME := $(shell uname -s | tr A-Z a-z)
+
 YAMLS = $(wildcard tests/*.yml)
 FBS = $(subst tests/,target/fb/,${YAMLS:.yml=.fb})
 HTMLS = $(subst fb/,html/,${FBS:.fb=.html})
@@ -49,6 +51,20 @@ target/html/%.html: target/output/%
 	while IFS= read -r xpath; do
 		xmllint --xpath "$${xpath}" "$$(dirname "$@")/$${n}-vitals.html" > /dev/null
 	done <<< "$${xpaths}"
+	set +e
+	tidy -e "$$(dirname "$@")/$${n}.html"
+	result=$?
+	if [ "$${result}" -eq "2" ]; then
+		echo "$$(dirname "$@")/$${n}.html has errors"
+		exit 1
+	fi
+	tidy -e "$$(dirname "$@")/$${n}-vitals.html"
+	result=$?
+	if [ "$${result}" -eq "2" ]; then
+		echo "$$(dirname "$@")/$${n}-vitals.html has errors"
+		exit 1
+	fi
+	set -e
 
 target/fb/%.fb: tests/%.yml Makefile | target/fb
 	if [ -e "$@" ]; then $(JUDGES) trim --query='(always)' "$@"; fi
@@ -78,6 +94,13 @@ $(SAXON): | target
 
 install: $(SAXON) | target
 	bundle install
+	if [ "$(OS_NAME)" = "darwin" ]; then
+		brew install tidy-html5
+	else
+		if ! ([ -f /proc/self/cgroup ] && grep -q ":" /proc/self/cgroup); then
+			apt-get install -y tidy
+		fi
+	fi
 	npm --no-color install -g eslint@9.22.0
 	npm --no-color install -g uglify-js
 	npm --no-color install -g sass@1.77.2

--- a/Makefile
+++ b/Makefile
@@ -51,20 +51,17 @@ target/html/%.html: target/output/%
 	while IFS= read -r xpath; do
 		xmllint --xpath "$${xpath}" "$$(dirname "$@")/$${n}-vitals.html" > /dev/null
 	done <<< "$${xpaths}"
-	set +e
-	tidy -e "$$(dirname "$@")/$${n}.html"
-	result=$?
+	result=0
+	tidy -e "$$(dirname "$@")/$${n}.html" || result=$?
 	if [ "$${result}" -eq "2" ]; then
 		echo "$$(dirname "$@")/$${n}.html has errors"
 		exit 1
 	fi
-	tidy -e "$$(dirname "$@")/$${n}-vitals.html"
-	result=$?
+	tidy -e "$$(dirname "$@")/$${n}-vitals.html" || result=$?
 	if [ "$${result}" -eq "2" ]; then
 		echo "$$(dirname "$@")/$${n}-vitals.html has errors"
 		exit 1
 	fi
-	set -e
 
 target/fb/%.fb: tests/%.yml Makefile | target/fb
 	if [ -e "$@" ]; then $(JUDGES) trim --query='(always)' "$@"; fi


### PR DESCRIPTION
Hello, @yegor256 

This pr based on #72 issue.

Couple of comments:
- I am using mac, so I am checking OS, before installing tidy
- For linux it's checking if it is in dockerenv `([ -f /proc/self/cgroup ] && grep -q ":" /proc/self/cgroup)`.
Typically, it's enough to check `-f /.dockerenv` and search for "docker" in "/proc/self/cgroup", but I am using colima as docker engine. So, I modified it a bit as methods above does not detect docker env.
- Finally, tidy can return 1, 2 as exit codes. 1 for warnings, which I've decided to ignore.

My checks are green. Could you check it?