### PR TITLE
check .js files with eslint

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY judges /home/judges
 COPY sass /home/sass
 COPY xsl /home/xsl
 COPY js /home/js
+COPY eslint.config.js /home
 RUN make --directory=/home --no-silent install assets
 
 COPY entry.sh /home

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ $(SAXON): | target
 
 install: $(SAXON) | target
 	bundle install
-	npm --no-color install -g eslint
+	npm --no-color install -g eslint@9.22.0
 	npm --no-color install -g uglify-js
 	npm --no-color install -g sass@1.77.2
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ $(CSS): sass/*.scss Makefile | target/css
 	sass --no-source-map --style=compressed --no-quiet --stop-on-error sass/main.scss "$@"
 
 $(JS): js/*.js Makefile | target/js
+	eslint js/*.js
 	uglifyjs js/*.js > "$@"
 
 clean:
@@ -77,6 +78,7 @@ $(SAXON): | target
 
 install: $(SAXON) | target
 	bundle install
+	npm --no-color install -g eslint
 	npm --no-color install -g uglify-js
 	npm --no-color install -g sass@1.77.2
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+ * SPDX-License-Identifier: MIT
+ */
+
+module.exports = [
+  {
+    rules: {
+      semi: "error",
+      "prefer-const": "error"
+    },
+    ignores: ["target/**/*"]
+  }
+];


### PR DESCRIPTION
Hello, @yegor256 

This pr related to #82 

I've added eslint. And also changed node version from 16 to 18 in make workflow, due to these reasons:
- it correlates with docker, which is installing 18th version
- eslint with node 16 does not support lots of rules, such as "semi"

What about rules, standart configs? What do you prefer?