### PR TITLE
 66 Improve QoS section rendering: add legend positioning and snake_case-to-title conversion

### DIFF
--- a/js/qo-section.js
+++ b/js/qo-section.js
@@ -16,6 +16,11 @@ function qo_render(canvas, data) {
     data: data,
     options: {
       responsive: false,
+      plugins: {
+        legend: {
+          position: 'right'
+        }
+      }
     }
   });
 }

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024 Yegor Bugayenko
+# License:: MIT
+class TestQoSection < Minitest::Test
+  def test_snake_case_to_title
+    xml = xslt(
+      '<r><xsl:value-of select="z:snake-case-to-title(\'average_issue_lifetime\')"/></r>',
+      '
+      <fb>
+        <f>
+          <when>2024-08-03T22:22:22.8492Z</when>
+          <what>quality-of-service</what>
+        </f>
+      </fb>
+      ',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    assert_equal('Average Issue Lifetime', xml.xpath('//r/text()').to_s.strip)
+  end
+end

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -3,7 +3,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
+  <xsl:function name="z:snake-case-to-title" as="xs:string">
+    <xsl:param name="line" as="xs:string"/>
+    <xsl:variable name="words" select="tokenize($line, '_')"/>
+    <xsl:value-of select="string-join(for $word in $words return concat(upper-case(substring($word, 1, 1)), substring($word, 2)), ' ')"/>
+  </xsl:function>
   <xsl:template name="qo-section">
     <xsl:param name="what" as="xs:string"/>
     <xsl:param name="title" as="xs:string"/>
@@ -51,7 +56,7 @@
               <xsl:text>,</xsl:text>
             </xsl:if>
             <xsl:text>{label:'</xsl:text>
-            <xsl:value-of select="substring-after($n, 'n_')"/>
+            <xsl:value-of select="z:snake-case-to-title(substring-after($n, 'n_'))"/>
             <xsl:text>',borderColor:</xsl:text>
             <xsl:variable name='c' select="substring-before(substring-after(concat(',', $colors, ','), concat(',', $n, ':')), ',')"/>
             <xsl:choose>


### PR DESCRIPTION
Closes #66 

This pull request introduces improvements to the rendering and labeling of "quality of service" (QoS) sections, focusing on better chart legend positioning and more readable chart labels. It also adds a utility function for converting snake_case strings to Title Case, along with a corresponding test.

**Chart rendering and labeling improvements:**

* The chart legend in `qo_render` is now positioned on the right for better visibility and layout. (`js/qo-section.js`)
* Chart labels are now automatically converted from snake_case to Title Case using a new XSLT function, making them more user-friendly. (`xsl/qo-section.xsl`)

**Utility function and testing:**

* Added a new XSLT function `z:snake-case-to-title` to convert snake_case strings to Title Case, and registered the `z` namespace. (`xsl/qo-section.xsl`)
* Introduced a test to verify that the new function correctly converts snake_case to Title Case. (`test/pages/test_qo_section.rb`)

<img width="1750" height="609" alt="QoS_example" src="https://github.com/user-attachments/assets/eed90eef-3c16-41b3-b422-25cec664f450" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart legend now positioned on the right side for improved layout.
  * Data labels display with enhanced formatting and readability using proper title case conversion.

* **Tests**
  * Added test coverage for label formatting functionality to ensure consistent output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->