### PR TITLE
Integrate palette.css and remove redundant styles

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -7,16 +7,9 @@
 @use 'bylaws' as *;
 @use 'qo-section' as *;
 
-@import url('https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap');
-
-$black: #131515;
-$gray: #282828;
 
 body,
 body * {
-  font-family: "Noto Sans", sans-serif;
 }
 
 code,

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -20,7 +20,6 @@ section {
 }
 
 footer {
-    color: $gray;
     font-size: 0.8em;
     line-height: 1.2em;
     text-align: center;

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -8,9 +8,6 @@
 @use 'qo-section' as *;
 
 
-body,
-body * {
-}
 
 code,
 pre,

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -42,7 +42,6 @@ header {
     }
 
     span {
-        background-color: $black;
         border-radius: .2em;
         color: white;
         font-size: 2em;

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -114,7 +114,7 @@
         <xsl:if test="$logo != ''">
           <link rel="icon" href="https://www.zerocracy.com/svg/logo.svg" type="image/svg"/>
         </xsl:if>
-                    <xsl:if test="not($adless='yes')">
+                    <xsl:if='true' test="not($adless='yes')">
               <link rel="stylesheet" href="https://www.zerocracy.com/css/palette.css"/>
                                   </xsl:if>
         <xsl:call-template name="css-links">

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -114,6 +114,7 @@
         <xsl:if test="$logo != ''">
           <link rel="icon" href="https://www.zerocracy.com/svg/logo.svg" type="image/svg"/>
         </xsl:if>
+              <link rel="stylesheet" href="https://www.zerocracy.com/css/palette.css"/>
         <xsl:call-template name="css-links">
           <xsl:with-param name="links" select="$css-links"/>
         </xsl:call-template>

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -114,7 +114,9 @@
         <xsl:if test="$logo != ''">
           <link rel="icon" href="https://www.zerocracy.com/svg/logo.svg" type="image/svg"/>
         </xsl:if>
+                    <xsl:if test="not($adless='yes')">
               <link rel="stylesheet" href="https://www.zerocracy.com/css/palette.css"/>
+                                  </xsl:if>
         <xsl:call-template name="css-links">
           <xsl:with-param name="links" select="$css-links"/>
         </xsl:call-template>


### PR DESCRIPTION
This PR integrates the zerocracy palette.css stylesheet and removes redundant color and font definitions to improve code maintainability.

Changes made:
- Added palette.css link to vitals.xsl template head section
- Removed Google Fonts imports from main.scss
- Removed $black and $gray color variables from main.scss
- Removed redundant font-family declaration from body selector

Resolves #460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed bundled default font imports and stopped forcing a global font-family; removed predefined black/gray color tokens and their uses while keeping monospace for code elements.
* **New Features**
  * Added a conditional external palette stylesheet that loads only when the "adless" setting is not enabled, affecting page color theming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->