### PR TITLE
set "unknown" value of version if version checking was failed

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -13,11 +13,11 @@ if [ -z "${LATEST_VERSION}" ]; then
         LATEST_VERSION=$(curl -s --max-time 10 https://api.github.com/repos/zerocracy/pages-action/releases/latest | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' || echo "")
         if [ -z "${LATEST_VERSION}" ]; then
             echo "Could not fetch latest version from GitHub API"
-            LATEST_VERSION="${VERSION}"
+            LATEST_VERSION="unknown"
         fi
     else
         echo "curl not available, skipping version check"
-        LATEST_VERSION="${VERSION}"
+        LATEST_VERSION="unknown"
     fi
 fi
 


### PR DESCRIPTION
Closes: #514
set "unknown" value of version if version checking was failed because there is a [renders-version-mismatch-banner](https://github.com/zerocracy/pages-action/blob/master/entries/renders-version-mismatch-banner.sh) test that fails if githgub api fails on last version request. 
Before the changes api request failing handled with setting same `0.0.0` value for current and last versions, so identical versions made version-mismatch-banner not rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling to display "unknown" when the latest version cannot be retrieved due to API unavailability or missing system dependencies, ensuring more accurate version information is presented to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->