### PR TITLE
add dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ You need to have
   [Node], [Npm],
   [Java],
   [xmllint],
+  [HTML Tidy],
+  [OpenSSL],
   and
   [Docker]
   installed.
@@ -84,3 +86,5 @@ Then, you should be able to open the `target/html/simple-vitals.html`
 [Npm]: https://www.npmjs.com/
 [xmllint]: https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html
 [Java]: https://www.java.com/en/
+[HTML Tidy]: https://www.html-tidy.org/
+[OpenSSL]: https://www.openssl.org/


### PR DESCRIPTION
Close #471 
On desktop Linux distributions, `HTML Tidy` and `OpenSSL` need to be installed manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect newly required prerequisite dependencies: HTML Tidy and OpenSSL are now needed for building the project and contributing to development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->