### PR TITLE
#67: Add horizontal axis markers to QoS graph

### DIFF
--- a/js/qo-section.js
+++ b/js/qo-section.js
@@ -20,6 +20,15 @@ function qo_render(canvas, data) {
         legend: {
           position: 'right'
         }
+      },
+      scales: {
+        x: {
+          ticks: {
+            maxRotation: 45,
+            autoSkip: true,
+            maxTicksLimit: 12
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary

Fixes #67

Currently, no markers are shown on the x-axis in QoS graphs. This PR adds `scales.x` configuration to the Chart.js `qo_render()` function, enabling x-axis tick labels with:

- `maxRotation: 45` — angled labels to avoid overlap
- `autoSkip: true` — skip labels when too dense
- `maxTicksLimit: 12` — reasonable upper limit

## How to test

1. Build assets: `make assets`
2. Generate HTML from test YAML: `make target/html/single-qos.html`
3. Open in browser — x-axis should now show date markers

## Files changed

- `js/qo-section.js` — added `scales.x` options to Chart.js config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved line chart x-axis label readability with enhanced label rotation and optimized tick management to prevent overcrowding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->