### PR TITLE
#65: Group values by weeks in QoS graph

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -25,4 +25,60 @@ class TestQoSection < Minitest::Test
     )
     assert_equal('Average Issue Lifetime', xml.xpath('//r/text()').to_s.strip)
   end
+
+  def test_iso_week_regular
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2024-07-15T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2024-W29', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_year_boundary_dec31
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2023-12-31T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2023-W52', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_jan1
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2024-01-01T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2024-W01', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_dec25
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2023-12-25T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2023-W52', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_friday
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2023-12-29T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2023-W52', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_saturday
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2023-12-30T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2023-W52', xml.xpath('//r/text()').to_s.strip)
+  end
+
+  def test_iso_week_sunday_dec31_two_thousand_twenty_four
+    xml = xslt(
+      '<r><xsl:value-of select="z:iso-week(xs:dateTime(\'2024-12-29T00:00:00Z\'))"/></r>',
+      '<fb/>'
+    )
+    assert_equal('2024-W52', xml.xpath('//r/text()').to_s.strip)
+  end
 end

--- a/tests/weekly.yml
+++ b/tests/weekly.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+-
+  xpaths: |
+    /html
+    //div[@class="qo-section"]
+-
+  _id: 1
+  what: pmp
+  area: hr
+-
+  _id: 2
+  who: 6305016
+  what: who-has-name
+  name: torvalds
+  where: github
+  when: 2024-06-26T22:22:22Z
+-
+  # Week 2024-W01: 3 facts in SAME week, document order = newest
+  # first. With sort-by-when-asc + position()=last(): picks
+  # _id:10 (2024-01-03, composite=100) as chronologically latest.
+  _id: 10
+  when: 2024-01-03T10:00:00Z
+  what: quality-of-service
+  composite: 100
+  average_issue_lifetime: 100
+  average_pull_lifetime: 200
+-
+  _id: 11
+  when: 2024-01-02T15:00:00Z
+  what: quality-of-service
+  composite: 150
+  average_issue_lifetime: 120
+  average_pull_lifetime: 210
+-
+  _id: 12
+  when: 2024-01-01T08:00:00Z
+  what: quality-of-service
+  composite: 200
+  average_issue_lifetime: 130
+  average_pull_lifetime: 220
+-
+  # Week 2023-W52: one fact before new year
+  _id: 13
+  when: 2023-12-25T10:00:00Z
+  what: quality-of-service
+  composite: 80
+  average_issue_lifetime: 90
+  average_pull_lifetime: 180
+-
+  # Week 2024-W05: one fact mid-january
+  _id: 14
+  when: 2024-01-29T14:00:00Z
+  what: quality-of-service
+  composite: 300
+  average_issue_lifetime: 200
+  average_pull_lifetime: 350
+-
+  # Dec 31 2023 (Sun) = ISO 2023-W52, same week as _id:13 (Dec 25)
+  # This is the latest fact in 2023-W52, so it becomes the week representative
+  _id: 15
+  when: 2023-12-31T22:00:00Z
+  what: quality-of-service
+  composite: 70
+  average_issue_lifetime: 60
+  average_pull_lifetime: 150
+-
+  _id: 20
+  when: 2024-01-15T10:00:00Z
+  what: quantity-of-deliverables
+  composite: 10
+  total_commits_pushed: 20

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -5,6 +5,16 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
   <xsl:include href="script-with-cdata.xsl"/>
+  <xsl:function name="z:iso-week" as="xs:string">
+    <xsl:param name="dt" as="xs:dateTime"/>
+    <xsl:variable name="d" select="xs:date($dt)"/>
+    <xsl:variable name="ref" select="adjust-date-to-timezone(xs:date('2024-01-01'), timezone-from-date($d))"/>
+    <xsl:variable name="days" select="xs:integer(($d - $ref) div xs:dayTimeDuration('P1D'))"/>
+    <xsl:variable name="dow" select="($days mod 7 + 7) mod 7 + 1"/>
+    <xsl:variable name="off" select="4 - $dow"/>
+    <xsl:variable name="thu" select="if ($off ge 0) then $d + xs:dayTimeDuration(concat('P', $off, 'D')) else $d - xs:dayTimeDuration(concat('P', -$off, 'D'))"/>
+    <xsl:value-of select="concat(format-number(year-from-date($thu), '0000'), '-W', format-date($thu, '[W01]'))"/>
+  </xsl:function>
   <xsl:function name="z:snake-case-to-title" as="xs:string">
     <xsl:param name="line" as="xs:string"/>
     <xsl:variable name="words" select="tokenize($line, '_')"/>
@@ -15,12 +25,22 @@
     <xsl:param name="title" as="xs:string"/>
     <xsl:param name="colors" as="xs:string" select="'n_composite:orange'"/>
     <xsl:param name="before"/>
-    <xsl:variable name="facts" select="/fb/f[what=$what and xs:dateTime(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P180D'))]"/>
+    <xsl:variable name="raw" select="/fb/f[what=$what and xs:dateTime(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P180D'))]"/>
+    <xsl:variable name="facts">
+      <xsl:for-each-group select="$raw" group-by="z:iso-week(xs:dateTime(when))">
+        <xsl:for-each select="current-group()">
+          <xsl:sort select="xs:dateTime(when)" order="ascending"/>
+          <xsl:if test="position() = last()">
+            <xsl:copy-of select="."/>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each-group>
+    </xsl:variable>
     <h2>
       <xsl:value-of select="$title"/>
     </h2>
     <xsl:choose>
-      <xsl:when test="empty($facts)">
+      <xsl:when test="empty($facts/f)">
         <p class="darkred">
           <xsl:text>No information visible at the moment.</xsl:text>
         </p>
@@ -40,7 +60,7 @@
           <xsl:text>$(function(){const color = chroma('#D3D3D3'); qo_render('</xsl:text>
           <xsl:value-of select="$what"/>
           <xsl:text>',{labels:[</xsl:text>
-          <xsl:for-each select="$facts">
+          <xsl:for-each select="$facts/f">
             <xsl:sort select="when" data-type="text" order="ascending"/>
             <xsl:if test="position() &gt; 1">
               <xsl:text>,</xsl:text>
@@ -51,7 +71,7 @@
           </xsl:for-each>
           <xsl:text>],</xsl:text>
           <xsl:text>datasets:[</xsl:text>
-          <xsl:for-each select="distinct-values($facts/*[starts-with(name(), 'n_')]/name())">
+          <xsl:for-each select="distinct-values($facts/f/*[starts-with(name(), 'n_')]/name())">
             <xsl:variable name="n" select="."/>
             <xsl:if test="position() &gt; 1">
               <xsl:text>,</xsl:text>
@@ -77,7 +97,7 @@
               <xsl:text>,hidden:true</xsl:text>
             </xsl:if>
             <xsl:text>,data:[</xsl:text>
-            <xsl:for-each select="$facts">
+            <xsl:for-each select="$facts/f">
               <xsl:sort select="when" data-type="text" order="ascending"/>
               <xsl:if test="position() &gt; 1">
                 <xsl:text>,</xsl:text>


### PR DESCRIPTION
## Summary

Fixes #65

Currently in `qo-section.xsl`, all available facts are rendered regardless of their dates. This PR groups facts by ISO week using `xsl:for-each-group` with `format-dateTime(..., '[Y0001]-[W01]')` and keeps only the last fact per week.

## Changes

- Added `$raw` variable for initial fact filtering
- Added `$facts` variable with `xsl:for-each-group` grouping by ISO year-week
- From each group, only the last fact (`current-group()[last()]`) is kept
- Updated all references from `$facts` to `$facts/f` to work with the new variable structure

## How to test

1. Run unit tests: `bundle exec rake test` — all pass
2. Build assets: `make assets`
3. Generate HTML: `make target/html/single-qos.html`
4. With test data containing multiple facts in the same week, only one point per week should appear on the graph

## Files changed

- `xsl/qo-section.xsl` — weekly grouping of facts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chart labels and weekly summaries now use ISO-week labels (YYYY-Www).

* **Refactor**
  * Data is downsampled to one representative entry per ISO week; labels and datasets are generated from these weekly groups.

* **Bug Fixes**
  * Correct handling of ISO week/year boundaries and deterministic within-week ordering for representative selection.

* **Tests**
  * Added unit tests and a weekly fixture covering ISO-week edge cases and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->