### PR TITLE
#402: validate inline JS syntax in generated HTML

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -81,4 +81,41 @@ class TestQoSection < Minitest::Test
     )
     assert_equal('2024-W52', xml.xpath('//r/text()').to_s.strip)
   end
+
+  def test_inline_js_syntax_in_generated_html
+    skip('node is not installed') unless system('which node > /dev/null 2>&1')
+    xml = xslt(
+      "<r><xsl:call-template name='qo-section'>" \
+      "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
+      "<xsl:with-param name='title' select=\"'QoS'\"/>" \
+      "</xsl:call-template></r>",
+      '<fb>
+        <f>
+          <when>2024-07-03T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.5</n_composite>
+          <n_average_issue_lifetime>-0.3</n_average_issue_lifetime>
+        </f>
+        <f>
+          <when>2024-06-23T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.8</n_composite>
+          <n_average_issue_lifetime>0.1</n_average_issue_lifetime>
+        </f>
+      </fb>',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    scripts = xml.xpath('//script[not(@src)]')
+    refute_empty(scripts, 'Expected inline scripts to be generated')
+    scripts.each_with_index do |script, idx|
+      js = script.content.strip
+      next if js.empty?
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, "test_#{idx}.js")
+        File.write(file, js)
+        output = `node --check #{Shellwords.escape(file)} 2>&1`
+        assert($?.success?, "JS syntax error in script ##{idx}: #{output}\nContent: #{js}")
+      end
+    end
+  end
 end

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'English'
 require_relative '../test__helper'
 
 # Test.
@@ -83,7 +84,6 @@ class TestQoSection < Minitest::Test
   end
 
   def test_inline_js_syntax_in_generated_html
-    skip('node is not installed') unless system('which node > /dev/null 2>&1')
     xml = xslt(
       "<r><xsl:call-template name='qo-section'>" \
       "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
@@ -105,16 +105,14 @@ class TestQoSection < Minitest::Test
       </fb>',
       'today' => '2024-09-26T04:04:04Z'
     )
-    scripts = xml.xpath('//script[not(@src)]')
-    refute_empty(scripts, 'Expected inline scripts to be generated')
-    scripts.each_with_index do |script, idx|
-      js = script.content.strip
-      next if js.empty?
+    scripts = xml.xpath('//script[not(@src)]').map { |s| s.content.strip }.reject(&:empty?)
+    refute_empty(scripts, 'Expected non-empty inline scripts to be generated')
+    scripts.each_with_index do |js, idx|
       Dir.mktmpdir do |dir|
         file = File.join(dir, "test_#{idx}.js")
         File.write(file, js)
-        output = `node --check #{Shellwords.escape(file)} 2>&1`
-        assert($?.success?, "JS syntax error in script ##{idx}: #{output}\nContent: #{js}")
+        `node --check #{Shellwords.escape(file)} 2>&1`
+        assert_predicate($CHILD_STATUS, :success?, "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\nContent: #{js}")
       end
     end
   end

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -88,7 +88,7 @@ class TestQoSection < Minitest::Test
       "<r><xsl:call-template name='qo-section'>" \
       "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
       "<xsl:with-param name='title' select=\"'QoS'\"/>" \
-      "</xsl:call-template></r>",
+      '</xsl:call-template></r>',
       '<fb>
         <f>
           <when>2024-07-03T22:22:22Z</when>
@@ -111,8 +111,11 @@ class TestQoSection < Minitest::Test
       Dir.mktmpdir do |dir|
         file = File.join(dir, "test_#{idx}.js")
         File.write(file, js)
-        `node --check #{Shellwords.escape(file)} 2>&1`
-        assert_predicate($CHILD_STATUS, :success?, "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\nContent: #{js}")
+        output = `node --check #{Shellwords.escape(file)} 2>&1`
+        assert_predicate(
+          $CHILD_STATUS, :success?,
+          "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\n#{output}\nContent: #{js}"
+        )
       end
     end
   end


### PR DESCRIPTION
Fixes #402

## Summary

- Added `test_inline_js_syntax_in_generated_html` test that validates syntax of inline JavaScript generated by `qo-section.xsl`
- The test generates HTML via XSLT with QoS facts containing `n_` fields, extracts `<script>` blocks, and validates each with `node --check`
- Node.js is required (available in CI via `setup-node@v6`)

## Test plan

- [x] `bundle exec rake test` passes (17 tests, 44 assertions, 0 failures)
- [x] New test correctly detects JS syntax errors (verified manually)
- [x] Asserts at least one non-empty script is present and validated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure all generated inline JavaScript code has correct syntax, improving code quality and catching errors earlier in development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->