### PR TITLE
#111: validate HTML vitals page via W3C

### DIFF
--- a/entries/vitals-has-palette-option.sh
+++ b/entries/vitals-has-palette-option.sh
@@ -21,7 +21,7 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep '<html class="palette-dark">' 'output/test-vitals.html'
+grep 'class="palette-dark"' 'output/test-vitals.html'
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'GITHUB_REPOSITORY=foo/bar' \
@@ -34,7 +34,7 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep '<html class="palette-mild">' 'output/test-vitals.html'
+grep 'class="palette-mild"' 'output/test-vitals.html'
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'GITHUB_REPOSITORY=foo/bar' \
@@ -47,8 +47,9 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep '<html class="palette-classic">' 'output/test-vitals.html'
+grep 'class="palette-classic"' 'output/test-vitals.html'
 
+# Verify that the default palette is "classic" when INPUT_PALETTE is not set
 env "GITHUB_WORKSPACE=$(pwd)" \
   'GITHUB_REPOSITORY=foo/bar' \
   'GITHUB_REPOSITORY_OWNER=foo' \
@@ -59,4 +60,4 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep '<html class="palette-classic">' 'output/test-vitals.html'
+grep 'class="palette-classic"' 'output/test-vitals.html'

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -14,29 +14,19 @@ require_relative '../test__helper'
 # Copyright:: Copyright (c) 2024 Yegor Bugayenko
 # License:: MIT
 class TestVitals < Minitest::Test
-  def test_validate_html
+  def test_validate_html_via_w3c
     WebMock.enable_net_connect!
-    html = File.join(__dir__, '../../target/html/simple-vitals.html')
-    skip unless File.exist?(html)
-    doc = File.read(html)
-    xml =
-      begin
-        Nokogiri::XML.parse(doc) do |c|
-          c.norecover
-          c.strict
-        end
-      rescue StandardError => e
-        raise "#{doc}\n\n#{e}"
-      end
-    assert_empty(xml.errors, xml)
-    refute_empty(xml.xpath('/html'), xml)
-    return unless online?
-    WebMock.enable_net_connect!
+    skip('not online') unless online?
+    html = generate_vitals_html
     begin
-      v = W3CValidators::NuValidator.new.validate_file(html)
-      assert_empty(v.errors, "#{doc}\n\n#{v.errors.join('; ')}")
-    rescue Errno::ECONNRESET, W3CValidators::ValidatorUnavailable, W3CValidators::ParsingError, OpenSSL::SSL::SSLError
-      skip
+      v = W3CValidators::NuValidator.new.validate_text(html)
+      errors = v.errors.map { |e| "  Line #{e.line}: #{e.message.strip}" }.join("\n")
+      assert_empty(v.errors, "W3C validation errors:\n#{errors}\n\nHTML:\n#{html}")
+    rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT,
+           SocketError, Net::OpenTimeout, Net::ReadTimeout,
+           W3CValidators::ValidatorUnavailable, W3CValidators::ParsingError,
+           OpenSSL::SSL::SSLError
+      skip('W3C validator unavailable')
     end
   end
 
@@ -109,5 +99,66 @@ class TestVitals < Minitest::Test
     assert_includes(css, '.bylaws.columns{column-count:5}', 'Desktop layout broken')
     assert_includes(css, '@media(max-width:1280px){.bylaws.columns{column-count:2}}', 'Tablet layout broken')
     assert_includes(css, '@media(max-width:768px){.bylaws.columns{column-count:1}}', 'Phone layout broken')
+  end
+
+  private
+
+  def generate_vitals_html
+    saxon = File.join(__dir__, '../../target/saxon.jar')
+    skip("Saxon not built at #{saxon}") unless File.exist?(saxon)
+    Dir.mktmpdir do |dir|
+      input = File.join(dir, 'input.xml')
+      File.write(input, <<~XML)
+        <?xml version="1.0" encoding="UTF-8"?>
+        <fb>
+          <f>
+            <when>2024-07-03T22:22:22Z</when>
+            <what>quality-of-service</what>
+            <n_composite>0.5</n_composite>
+          </f>
+          <f>
+            <when>2024-07-01T22:22:22Z</when>
+            <award>14</award>
+            <who>526301</who>
+            <where>github</where>
+            <who_name>yegor256</who_name>
+            <is_human>1</is_human>
+            <why>test</why>
+            <repository>777</repository>
+          </f>
+          <f>
+            <who>526301</who>
+            <what>who-has-name</what>
+            <name>yegor256</name>
+            <where>github</where>
+            <when>2024-06-26T22:22:22Z</when>
+          </f>
+        </fb>
+      XML
+      output = File.join(dir, 'vitals.html')
+      qbash(
+        [
+          "java -jar #{Shellwords.escape(saxon)}",
+          "-s:#{Shellwords.escape(input)}",
+          "-xsl:#{Shellwords.escape(File.join(__dir__, '../../xsl/vitals.xsl'))}",
+          "-o:#{Shellwords.escape(output)}"
+        ] + %w[
+          today=2024-09-26T04:04:04Z
+          name=test
+          logo=x
+          palette=classic
+          url=https://example.com
+          version=0.0.1
+          latest-version=0.0.2
+          fbe=0.0.50
+          adless=false
+          css-links=
+          css=body{}
+          js=
+        ].map { |p| Shellwords.escape(p) },
+        stdout: fake_loog
+      )
+      File.read(output)
+    end
   end
 end

--- a/xsl/script-with-cdata.xsl
+++ b/xsl/script-with-cdata.xsl
@@ -10,7 +10,7 @@
   -->
   <xsl:template name="script-with-cdata">
     <xsl:param name="content"/>
-    <script type="text/javascript">
+    <script>
       <xsl:text disable-output-escaping="yes">//&lt;![CDATA[&#10;</xsl:text>
       <xsl:value-of select="$content" disable-output-escaping="yes"/>
       <xsl:text disable-output-escaping="yes">&#10;//]]&gt;</xsl:text>

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -94,7 +94,7 @@
   </xsl:function>
   <xsl:template name="javascript">
     <xsl:param name="url"/>
-    <script type="text/javascript" src="{$url}">
+    <script src="{$url}">
       <xsl:text> </xsl:text>
     </script>
   </xsl:template>
@@ -118,7 +118,7 @@
   </xsl:template>
   <xsl:template match="/">
     <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
-    <html>
+    <html lang="en">
       <xsl:attribute name="class">
           <xsl:value-of select="concat('palette-', $palette)"/>
       </xsl:attribute>


### PR DESCRIPTION
Fixes #111

## Problem

The existing test_validate_html test depended on a pre-built file (target/html/simple-vitals.html) that only exists after a full Docker build. This meant the test always skipped in normal bundle exec rake test runs, providing zero coverage for HTML validity.

Additionally, the generated HTML had unnecessary type="text/javascript" attributes on script tags and was missing a lang attribute on the html element - both flagged by the W3C NuValidator.

## Solution

Test rewrite: Replaced the pre-built file dependency with a generate_vitals_html helper that runs Saxon directly with vitals.xsl and minimal test XML data, then validates the output via W3CValidators::NuValidator. The test now runs as part of the normal test suite.

XSLT fixes:
- Removed type="text/javascript" from script tags in vitals.xsl and script-with-cdata.xsl (unnecessary in HTML5)
- Added lang="en" to the html element in vitals.xsl (accessibility and SEO)

## Validation result

The W3C NuValidator reports 0 errors on the generated HTML.

## Test plan

- [x] bundle exec rake test passes (11 tests, 16 assertions, 0 failures)
- [x] W3C NuValidator confirms 0 errors on generated HTML
- [x] test_validate_html_via_w3c runs in normal test suite (no Docker required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Script elements no longer include the redundant type attribute, producing cleaner markup.
  * HTML now includes a language declaration (lang="en") for better accessibility and standards compliance.
* **Tests**
  * HTML validation moved to an automated W3C-based validation step to ensure generated output meets standards.
* **Bug Fixes**
  * Palette detection in verification was made more robust, including a clarified default palette expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->