### PR TITLE
#581: fix supply-chain security issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'factbase', '~>0.17'
 gem 'fbe', '~>0.41'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (8.1.3)
       base64
@@ -197,7 +197,7 @@ GEM
     openssl (4.0.1)
     ostruct (0.6.3)
     others (0.1.1)
-    parallel (2.0.1)
+    parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ description: 'Build static pages from a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'
 runs:
   using: 'docker'
-  image: 'docker://yegor256/pages-action:latest'
+  image: 'docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08'
 inputs:
   verbose:
     description: 'Log as much debug information as possible'

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,7 @@ description: 'Build static pages from a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'
 runs:
   using: 'docker'
-  image: >-
-    docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08
+  image: 'docker://yegor256/pages-action:latest'
 inputs:
   verbose:
     description: 'Log as much debug information as possible'

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ description: 'Build static pages from a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'
 runs:
   using: 'docker'
-  image: 'docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08'
+  image: >-
+    docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08
 inputs:
   verbose:
     description: 'Log as much debug information as possible'

--- a/entry.sh
+++ b/entry.sh
@@ -215,6 +215,30 @@ for css in "${css_urls[@]}"; do
 done
 css_links="${css_links%$'\n'}"
 
+echo "Calculating integrity hashes for JS files..."
+declare -a js_urls=(
+    "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+    "https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"
+    "https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"
+    "https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.4.2/chroma.min.js"
+)
+js_links=""
+for js in "${js_urls[@]}"; do
+    echo "Calculating hash for: ${js}"
+    content=$(curl -sSf --max-time 30 "$js") || {
+        echo "ERROR: Failed to fetch JS from: ${js}" >&2
+        exit 1
+    }
+    hash=$(printf "%s" "$content" | openssl dgst -sha384 -binary | openssl base64 -A)
+    if [ -z "$hash" ]; then
+        echo "ERROR: Failed to calculate hash for: ${js}" >&2
+        exit 1
+    fi
+    echo "Hash: ${hash}"
+    js_links="${js_links}${js}|${hash}"$'\n'
+done
+js_links="${js_links%$'\n'}"
+
 java -jar "${SELF}/target/saxon.jar" \
     "-s:${INPUT_OUTPUT}/${name}.rich.xml" \
     "-xsl:${SELF}/target/xsl/vitals.xsl" \
@@ -229,6 +253,7 @@ java -jar "${SELF}/target/saxon.jar" \
     "url=${url}" \
     "adless=${INPUT_ADLESS}" \
     "css-links=${css_links}" \
+    "js-links=${js_links}" \
     "css=$(cat "${SELF}/target/css/main.css")" \
     "js=$(cat "${SELF}/${INPUT_JS_FILE:-target/js/main.js}")"
 html-minifier "${html}" --config-file "${SELF}/html-minifier-config.json" -o "${html}"

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -81,4 +81,41 @@ class TestQoSection < Minitest::Test
     )
     assert_equal('2024-W52', xml.xpath('//r/text()').to_s.strip)
   end
+
+  def test_inline_js_syntax_in_generated_html
+    skip('node is not installed') unless system('which node > /dev/null 2>&1')
+    xml = xslt(
+      "<r><xsl:call-template name='qo-section'>" \
+      "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
+      "<xsl:with-param name='title' select=\"'QoS'\"/>" \
+      "</xsl:call-template></r>",
+      '<fb>
+        <f>
+          <when>2024-07-03T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.5</n_composite>
+          <n_average_issue_lifetime>-0.3</n_average_issue_lifetime>
+        </f>
+        <f>
+          <when>2024-06-23T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.8</n_composite>
+          <n_average_issue_lifetime>0.1</n_average_issue_lifetime>
+        </f>
+      </fb>',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    scripts = xml.xpath('//script[not(@src)]')
+    refute_empty(scripts, 'Expected inline scripts to be generated')
+    scripts.each_with_index do |script, idx|
+      js = script.content.strip
+      next if js.empty?
+      Dir.mktmpdir do |dir|
+        file = File.join(dir, "test_#{idx}.js")
+        File.write(file, js)
+        output = `node --check #{Shellwords.escape(file)} 2>&1`
+        assert($?.success?, "JS syntax error in script ##{idx}: #{output}\nContent: #{js}")
+      end
+    end
+  end
 end

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'English'
 require_relative '../test__helper'
 
 # Test.
@@ -83,7 +84,6 @@ class TestQoSection < Minitest::Test
   end
 
   def test_inline_js_syntax_in_generated_html
-    skip('node is not installed') unless system('which node > /dev/null 2>&1')
     xml = xslt(
       "<r><xsl:call-template name='qo-section'>" \
       "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
@@ -105,16 +105,14 @@ class TestQoSection < Minitest::Test
       </fb>',
       'today' => '2024-09-26T04:04:04Z'
     )
-    scripts = xml.xpath('//script[not(@src)]')
-    refute_empty(scripts, 'Expected inline scripts to be generated')
-    scripts.each_with_index do |script, idx|
-      js = script.content.strip
-      next if js.empty?
+    scripts = xml.xpath('//script[not(@src)]').map { |s| s.content.strip }.reject(&:empty?)
+    refute_empty(scripts, 'Expected non-empty inline scripts to be generated')
+    scripts.each_with_index do |js, idx|
       Dir.mktmpdir do |dir|
         file = File.join(dir, "test_#{idx}.js")
         File.write(file, js)
-        output = `node --check #{Shellwords.escape(file)} 2>&1`
-        assert($?.success?, "JS syntax error in script ##{idx}: #{output}\nContent: #{js}")
+        `node --check #{Shellwords.escape(file)} 2>&1`
+        assert_predicate($CHILD_STATUS, :success?, "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\nContent: #{js}")
       end
     end
   end

--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -88,7 +88,7 @@ class TestQoSection < Minitest::Test
       "<r><xsl:call-template name='qo-section'>" \
       "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
       "<xsl:with-param name='title' select=\"'QoS'\"/>" \
-      "</xsl:call-template></r>",
+      '</xsl:call-template></r>',
       '<fb>
         <f>
           <when>2024-07-03T22:22:22Z</when>
@@ -111,8 +111,11 @@ class TestQoSection < Minitest::Test
       Dir.mktmpdir do |dir|
         file = File.join(dir, "test_#{idx}.js")
         File.write(file, js)
-        `node --check #{Shellwords.escape(file)} 2>&1`
-        assert_predicate($CHILD_STATUS, :success?, "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\nContent: #{js}")
+        output = `node --check #{Shellwords.escape(file)} 2>&1`
+        assert_predicate(
+          $CHILD_STATUS, :success?,
+          "JS syntax error in script ##{idx}: #{$CHILD_STATUS}\n#{output}\nContent: #{js}"
+        )
       end
     end
   end

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -153,6 +153,7 @@ class TestVitals < Minitest::Test
           fbe=0.0.50
           adless=false
           css-links=
+          js-links=
           css=body{}
           js=
         ].map { |p| Shellwords.escape(p) },

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -18,6 +18,7 @@
   <xsl:param name="fbe" as="xs:string"/>
   <xsl:param name="adless" as="xs:string"/>
   <xsl:param name="css-links" as="xs:string"/>
+  <xsl:param name="js-links" as="xs:string"/>
   <xsl:import href="awards.xsl"/>
   <xsl:import href="assessment.xsl"/>
   <xsl:import href="repositories.xsl"/>
@@ -94,9 +95,29 @@
   </xsl:function>
   <xsl:template name="javascript">
     <xsl:param name="url"/>
+    <xsl:param name="integrity"/>
     <script src="{$url}">
+      <xsl:if test="$integrity != ''">
+        <xsl:attribute name="integrity">
+          <xsl:value-of select="concat('sha384-', $integrity)"/>
+        </xsl:attribute>
+        <xsl:attribute name="crossorigin">anonymous</xsl:attribute>
+      </xsl:if>
       <xsl:text> </xsl:text>
     </script>
+  </xsl:template>
+  <xsl:template name="js-links">
+    <xsl:param name="links"/>
+    <xsl:variable name="lines" select="tokenize($links, '\n')"/>
+    <xsl:for-each select="$lines[normalize-space(.) != '']">
+      <xsl:variable name="parts" select="tokenize(., '\|')"/>
+      <xsl:if test="count($parts) = 2">
+        <xsl:call-template name="javascript">
+          <xsl:with-param name="url" select="normalize-space($parts[1])"/>
+          <xsl:with-param name="integrity" select="normalize-space($parts[2])"/>
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:for-each>
   </xsl:template>
   <xsl:template name="css">
     <xsl:param name="url"/>
@@ -169,18 +190,9 @@
         <xsl:call-template name="css-links">
           <xsl:with-param name="links" select="$css-links"/>
         </xsl:call-template>
-        <xsl:for-each select="(
-          'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js',
-          'https://cdn.jsdelivr.net/npm/chart.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.4.2/chroma.min.js'
-          )">
-          <xsl:call-template name="javascript">
-            <xsl:with-param name="url">
-              <xsl:value-of select="."/>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:for-each>
+        <xsl:call-template name="js-links">
+          <xsl:with-param name="links" select="$js-links"/>
+        </xsl:call-template>
         <xsl:call-template name="script-with-cdata">
           <xsl:with-param name="content" select="$js"/>
         </xsl:call-template>


### PR DESCRIPTION
Fixes #581

- **Docker digest pin** — `action.yml` now uses `docker://yegor256/pages-action@sha256:d62ca44b...` instead of mutable `:latest` tag
- **Gemfile HTTPS** — Changed `source 'http://rubygems.org'` to `https://rubygems.org`
- **JS SRI** — CDN `<script>` tags now include `integrity="sha384-..."` and `crossorigin="anonymous"`, matching the existing CSS SRI pattern. Hashes are computed at build time in `entry.sh`. Also pinned chart.js to `@4.4.7` instead of floating `latest`
