### PR TITLE
#460: integrate palette.css, remove redundant CSS

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -197,6 +197,7 @@ echo "Calculating integrity hashes for CSS files..."
 declare -a css_urls=(
     "https://cdn.jsdelivr.net/npm/tacit-css@1.9.5/dist/tacit-css.min.css"
     "https://cdn.jsdelivr.net/npm/drops@0.3.2/dist/drops-0.3.2.min.css"
+    "https://www.zerocracy.com/css/palette.css"
 )
 css_links=""
 for css in "${css_urls[@]}"; do

--- a/sass/awards.scss
+++ b/sass/awards.scss
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-$highlight: #f5f5f5;
-
 #awards {
   tr.sub td {
     padding: 0;
@@ -12,10 +10,6 @@ $highlight: #f5f5f5;
 
   .sorter {
     cursor: pointer;
-  }
-
-  tbody tr:hover {
-    background-color: $highlight;
   }
 
   tr.p-table {

--- a/sass/bylaws.scss
+++ b/sass/bylaws.scss
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-$strong: darkred;
-$em: #275a90;
-
 .bylaws {
     counter-reset: par;
 
@@ -22,14 +19,10 @@ $em: #275a90;
         }
 
         strong {
-            color: $strong;
-            font-family: "Roboto Mono", monospace;
             font-weight: normal;
         }
 
         em {
-            color: $em;
-            font-family: "Noto Serif", sans-serif;
             font-style: normal;
             font-weight: normal;
         }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,5 +1,4 @@
 /**
-
  * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
  * SPDX-License-Identifier: MIT
  */
@@ -8,30 +7,11 @@
 @use 'bylaws' as *;
 @use 'qo-section' as *;
 
-@import url('https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&display=swap');
-
-$black: #131515;
-$gray: #282828;
-
-body,
-body * {
-  font-family: "Noto Sans", sans-serif;
-}
-
-code,
-pre,
-tt {
-  font-family: "Roboto Mono", monospace;
-}
-
 section {
     width: auto;
 }
 
 footer {
-    color: $gray;
     font-size: 0.8em;
     line-height: 1.2em;
     text-align: center;
@@ -54,9 +34,7 @@ header {
     }
 
     span {
-        background-color: $black;
         border-radius: .2em;
-        color: white;
         font-size: 2em;
         font-weight: bolder;
         margin-left: 1em;
@@ -68,68 +46,3 @@ header {
 .ff {
     font-family: monospace;
 }
-
-/* stylelint-disable no-descending-specificity */
-
-/* @todo #31 Implement dark palette.
-    This dark color palette was roughly made and needs improving. */
-.palette-dark {
-  body {
-    color: #eee;
-    background-color: $black;
-  }
-
-  h1, h2, h3, h4, h5, h6 {
-    color: #eee;
-  }
-
-  header {
-    span {
-      background-color: #eee;
-      color: $black;
-    }
-  }
-
-  .warning {
-    span {
-      color: $black;
-    }
-  }
-
-  footer {
-    color: #aaa;
-  }
-
-}
-
-/* @todo #31 Implement mild palette.
-    This mil color palette was roughly made and needs improving. */
-.palette-mild {
-  body {
-    color: #333;
-    background-color: #999;
-  }
-
-  h1, h2, h3, h4, h5, h6 {
-    color: #333;
-  }
-
-  header {
-    span {
-      background-color: #999;
-      color: #333;
-    }
-  }
-
-  .warning {
-    span {
-      color: white;
-    }
-  }
-
-  footer {
-    color: #444;
-  }
-}
-
-/* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
Fixes #460

- Added `palette.css` to `css_urls` array in `entry.sh` for SRI-protected loading
- Removed all color/font definitions from SCSS that are now provided by `palette.css`:
  - Google Font imports (Noto Serif, Noto Sans, Roboto Mono)
  - Color variables (`$black`, `$gray`, `$strong`, `$em`, `$highlight`)
  - Body/footer/header color rules
  - `.palette-dark` and `.palette-mild` blocks (no dark palette exists per discussion in #460)
- Kept all structural/layout CSS and `.ff { font-family: monospace }` utility class