### PR TITLE
#588: render assessment and repository dates as relative time

### DIFF
--- a/test/pages/test_assessment.rb
+++ b/test/pages/test_assessment.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024 Yegor Bugayenko
+# License:: MIT
+class TestAssessment < Minitest::Test
+  def test_emits_relative_time_for_assessment_date
+    xml = xslt(
+      '<xsl:apply-templates select="/fb/f"/>',
+      '
+      <fb>
+        <f>
+          <what>latest-assessment</what>
+          <text>The factbase is fine.</text>
+          <when>2024-07-05T00:00:00Z</when>
+          <total>1</total>
+        </f>
+      </fb>
+      '
+    )
+    times = xml.xpath('//*[local-name()="time" and @class="relative-time"]')
+    refute_empty(
+      times,
+      "Expected a <time class=\"relative-time\"> element so js/outdated.js can " \
+      "convert the assessment date to a human-readable relative time, but " \
+      "got: #{xml}"
+    )
+    assert(
+      times.any? { |t| t['datetime']&.start_with?('2024-07-05') },
+      "Expected the relative-time element to carry the assessment date in its " \
+      "datetime attribute, got: #{times.map { |t| t['datetime'] }.inspect}"
+    )
+  end
+end

--- a/test/pages/test_assessment.rb
+++ b/test/pages/test_assessment.rb
@@ -27,13 +27,12 @@ class TestAssessment < Minitest::Test
     times = xml.xpath('//*[local-name()="time" and @class="relative-time"]')
     refute_empty(
       times,
-      "Expected a <time class=\"relative-time\"> element so js/outdated.js can " \
-      "convert the assessment date to a human-readable relative time, but " \
-      "got: #{xml}"
+      'Expected a <time class="relative-time"> element so js/outdated.js can ' \
+      "convert the assessment date to a human-readable relative time, but got: #{xml}"
     )
     assert(
       times.any? { |t| t['datetime']&.start_with?('2024-07-05') },
-      "Expected the relative-time element to carry the assessment date in its " \
+      'Expected the relative-time element to carry the assessment date in its ' \
       "datetime attribute, got: #{times.map { |t| t['datetime'] }.inspect}"
     )
   end

--- a/test/pages/test_repositories.rb
+++ b/test/pages/test_repositories.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024 Yegor Bugayenko
+# License:: MIT
+class TestRepositories < Minitest::Test
+  def test_emits_relative_time_for_repository_updated_at
+    xml = xslt(
+      '<xsl:apply-templates mode="repositories" select="/"/>',
+      '
+      <fb>
+        <f>
+          <what>repo-details</what>
+          <repository_name>foo/bar</repository_name>
+          <description>desc</description>
+          <stars>1</stars>
+          <forks>2</forks>
+          <language>Ruby</language>
+          <open_issues>3</open_issues>
+          <updated_at>2024-07-05T00:00:00Z</updated_at>
+        </f>
+      </fb>
+      '
+    )
+    times = xml.xpath('//*[local-name()="time" and @class="relative-time"]')
+    refute_empty(
+      times,
+      "Expected a <time class=\"relative-time\"> element so js/outdated.js can " \
+      "convert the repository updated_at date to relative time, got: #{xml}"
+    )
+    assert(
+      times.any? { |t| t['datetime']&.start_with?('2024-07-05') },
+      "Expected the relative-time element to carry the updated_at date in its " \
+      "datetime attribute, got: #{times.map { |t| t['datetime'] }.inspect}"
+    )
+  end
+end

--- a/test/pages/test_repositories.rb
+++ b/test/pages/test_repositories.rb
@@ -31,12 +31,12 @@ class TestRepositories < Minitest::Test
     times = xml.xpath('//*[local-name()="time" and @class="relative-time"]')
     refute_empty(
       times,
-      "Expected a <time class=\"relative-time\"> element so js/outdated.js can " \
+      'Expected a <time class="relative-time"> element so js/outdated.js can ' \
       "convert the repository updated_at date to relative time, got: #{xml}"
     )
     assert(
       times.any? { |t| t['datetime']&.start_with?('2024-07-05') },
-      "Expected the relative-time element to carry the updated_at date in its " \
+      'Expected the relative-time element to carry the updated_at date in its ' \
       "datetime attribute, got: #{times.map { |t| t['datetime'] }.inspect}"
     )
   end

--- a/xsl/assessment.xsl
+++ b/xsl/assessment.xsl
@@ -14,8 +14,11 @@
       </h2>
       <pre>
         <xsl:value-of select="text"/>
-        <xsl:text>Last assessed on </xsl:text>
-        <xsl:value-of select="xs:date(xs:dateTime(when))"/>
+        <xsl:text>Last assessed </xsl:text>
+        <time class="relative-time" datetime="{when}" title="{when}">
+          <xsl:text>on </xsl:text>
+          <xsl:value-of select="xs:date(xs:dateTime(when))"/>
+        </time>
       </pre>
       <xsl:if test="total &gt; 1">
         <p class="darkred">

--- a/xsl/repositories.xsl
+++ b/xsl/repositories.xsl
@@ -34,8 +34,11 @@
               <xsl:value-of select="open_issues"/>
               <xsl:text> open issues</xsl:text>
               <xsl:if test="updated_at != ''">
-                <xsl:text> · updated </xsl:text>
-                <xsl:value-of select="substring(updated_at, 1, 10)"/>
+                <xsl:text> · </xsl:text>
+                <time class="relative-time" datetime="{updated_at}" title="{updated_at}">
+                  <xsl:text>updated </xsl:text>
+                  <xsl:value-of select="substring(updated_at, 1, 10)"/>
+                </time>
               </xsl:if>
               <xsl:text> ]</xsl:text>
             </li>


### PR DESCRIPTION
@yegor256 — this PR fixes #588 (vitals page ISO-8601 timestamps lack readability).

## What changed

`xsl/assessment.xsl` and `xsl/repositories.xsl` now wrap their dates in `<time class="relative-time" datetime="..." title="...">` elements:

- **Assessment section**: `Last assessed on 2024-07-05` → `<time class="relative-time" datetime="2024-07-05T00:00:00Z" title="2024-07-05T00:00:00Z">on 2024-07-05</time>` (preceded by `Last assessed `).
- **Repository section**: `· updated 2024-07-05` → `· <time class="relative-time" datetime="2024-07-05T00:00:00Z" title="2024-07-05T00:00:00Z">updated 2024-07-05</time>`.

The footer (`vitals.xsl`) was already wrapped in `<time class="relative-time">`, so it didn't need changes.

## Why this works without JS changes

`js/outdated.js#updateTimeDisplay()` already runs on page load (and once per minute afterwards) and selects every `time.relative-time[datetime]` element on the page, replacing its visible text with relative time (`3 days ago`, `2 months ago`, …). By introducing the markup in the two XSL templates that were missing it, the existing JS picks them up automatically. The original ISO date stays in the `title` attribute for hover precision, as suggested in the issue.

## Tests

Two new Ruby tests exercise the XSL templates directly:

- `test/pages/test_assessment.rb#test_emits_relative_time_for_assessment_date`
- `test/pages/test_repositories.rb#test_emits_relative_time_for_repository_updated_at`

Both fail on `master` (the templates emit raw text only) and pass on this branch. Each was committed before the fix (commit `7b1a8f4`) and verified to pass after the fix (commit `e27f285`).

## Verification

- `bundle exec rake test` — 26 tests, 51 assertions, 0 failures, 3 skips (pre-existing online/W3C-validator skips).
- `bundle exec rake rubocop` — 16 files, 0 offenses.
- `eslint js/*.js` — clean.
- `xcop xsl/assessment.xsl xsl/repositories.xsl` — clean.
- All 15 GitHub Actions jobs green: actionlint, bashate, checkmake, copyrights, hadolint, make, markdown-lint, pdd, reuse, shellcheck, stylelint, **test**, typos, xcop, yamllint.

Ready for merge.