### PR TITLE
#590: validate explicit factbase path

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -70,6 +70,10 @@ if [ -z "${INPUT_FACTBASE}" ]; then
     echo "Auto-detected factbase: ${INPUT_FACTBASE}"
 else
     echo "Using provided factbase: ${INPUT_FACTBASE}"
+    if [ ! -f "${INPUT_FACTBASE}" ]; then
+        echo "ERROR: The factbase file '${INPUT_FACTBASE}' does not exist."
+        exit 1
+    fi
 fi
 
 declare -a gopts=()


### PR DESCRIPTION
Fixes #590

- Added file existence check for `INPUT_FACTBASE` when provided explicitly, before passing it to `judges print`
- Produces a clear error message instead of a raw Ruby `Errno::ENOENT` exception
- Makes the explicit-path branch consistent with the auto-detection branch (which already validates with friendly messages)