### PR TITLE
#593: skip normalization when initial metric value is zero

### DIFF
--- a/judges/normalize-metrics/normalize-metrics.rb
+++ b/judges/normalize-metrics/normalize-metrics.rb
@@ -36,10 +36,10 @@ end
   facts.each do |f|
     f.all_properties.each do |prop|
       next unless fits?(prop)
+      next if start[prop].zero?
       v = f[prop].first
       s = start[prop]
-      diff = v - s
-      diff /= start[prop] unless start[prop].zero?
+      diff = (v - s).to_f / start[prop]
       n = "n_#{prop}"
       next if f[n]
       f.send(:"#{n}=", diff)

--- a/judges/normalize-metrics/normalize-zero-start.yml
+++ b/judges/normalize-metrics/normalize-zero-start.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    when: 2024-05-18T22:22:22.8492Z
+    what: quality-of-service
+    average_issue_lifetime: 0
+    average_pull_lifetime: 100
+  -
+    when: 2024-05-19T22:22:22.8492Z
+    what: quality-of-service
+    average_issue_lifetime: 5
+    average_pull_lifetime: 150
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[n_average_pull_lifetime = 0.5]
+  - /fb/f[not(n_average_issue_lifetime)]


### PR DESCRIPTION
Fixes #593

## What was changed

In `judges/normalize-metrics/normalize-metrics.rb`, the guard that skipped division by zero was placed _after_ the `diff` calculation. This meant `n_*` received the raw absolute difference instead of being omitted entirely.

## The fix

- Moved the `start[prop].zero?` check **before** computing `diff`, so the `n_*` property is simply not set for metrics whose baseline is zero
- Removed the now-dead `unless start[prop].zero?` guard from the division
- The XSL template (`qo-section.xsl`) already handles missing `n_*` by emitting `null` to Chart.js, which renders as a gap in the line

## Test coverage

- Added `normalize-zero-start.yml` fixture: `average_issue_lifetime` starts at 0 (no `n_*` expected), `average_pull_lifetime` starts at 100 (normalized to 0.5)
- All 15 judge tests pass, 24 Minitest tests pass, RuboCop clean