### PR TITLE
#572: add unambiguous date tooltips to QoS graph x-axis

### DIFF
--- a/js/qo-section.js
+++ b/js/qo-section.js
@@ -19,6 +19,16 @@ function qo_render(canvas, data) {
       plugins: {
         legend: {
           position: 'right'
+        },
+        tooltip: {
+          callbacks: {
+            title: function(items) {
+              if (data.fullDates) {
+                return data.fullDates[items[0].dataIndex];
+              }
+              return items[0].label;
+            }
+          }
         }
       },
       scales: {

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -69,6 +69,16 @@
             <xsl:value-of select="format-date(xs:date(xs:dateTime(when)), '[M1]/[D1]')"/>
             <xsl:text>'</xsl:text>
           </xsl:for-each>
+          <xsl:text>],fullDates:[</xsl:text>
+          <xsl:for-each select="$facts/f">
+            <xsl:sort select="when" data-type="text" order="ascending"/>
+            <xsl:if test="position() &gt; 1">
+              <xsl:text>,</xsl:text>
+            </xsl:if>
+            <xsl:text>'</xsl:text>
+            <xsl:value-of select="format-date(xs:date(xs:dateTime(when)), '[D1] [MN,*-3] [Y]')"/>
+            <xsl:text>'</xsl:text>
+          </xsl:for-each>
           <xsl:text>],</xsl:text>
           <xsl:text>datasets:[</xsl:text>
           <xsl:for-each select="distinct-values($facts/f/*[starts-with(name(), 'n_')]/name())">


### PR DESCRIPTION
Fixes #572

## Summary

- X-axis labels stay as compact `1/7` format (no space change)
- Added `fullDates` array in XSLT with unambiguous format like `3 Jul 2024` using `[D1] [MN,*-3] [Y]`
- Added Chart.js tooltip callback in `qo-section.js` so hovering over a data point shows the full date
- Existing tests pass (`bundle exec rake test` — 24 tests, 0 failures)
- `rubocop` and `eslint` clean


screen
<img width="1254" height="945" alt="image" src="https://github.com/user-attachments/assets/0ee1fad8-7af6-4721-9956-cfb37a7b9d0d" />

