### PR TITLE
#601: rescue NotFound/Unauthorized around Fbe.octo.repository in copy-repo-names

### DIFF
--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -10,7 +10,12 @@ known = Fbe.fb.query('(eq what "repo-details")').each.filter_map(&:repository).t
 ids = Fbe.fb.query('(exists repository)').each.map(&:repository).uniq - known
 return if ids.empty?
 
-repos = ids.to_h { |id| [id, Fbe.octo.repository(id)] }
+repos =
+  ids.each_with_object({}) do |id, h|
+    h[id] = Fbe.octo.repository(id)
+  rescue Octokit::NotFound, Octokit::Unauthorized
+    next
+  end
 
 repos.each do |id, json|
   d = Fbe.fb.insert

--- a/judges/copy-repo-names/skips-missing-repo.yml
+++ b/judges/copy-repo-names/skips-missing-repo.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    what: award
+    repository: 12345
+    where: github
+  -
+    what: award
+    repository: 404123
+    where: github
+expected:
+  - /fb/f[what='repo-details' and repository='12345']
+  - /fb[count(f[what='repo-details' and repository='404123'])=0]


### PR DESCRIPTION
The `Fbe.octo.repository` call inside `judges/copy-repo-names/copy-repo-names.rb:13` raises `Octokit::NotFound` (or `Octokit::Unauthorized`) the moment one of the ids in the unknown-repository list points at a deleted or inaccessible repository, and because the call sits inside `ids.to_h { ... }` a single bad id aborts the whole iteration and skips the `repo-details` insert for every reachable repository on that pass. #601 documents the failure mode and the rescue convention already used for the same `Fbe.octo.*` pattern in `zerocracy/judges-action` (issues #1357–#1362).

The body of the judge now walks the same id list with `each_with_object({})` and rescues `Octokit::NotFound, Octokit::Unauthorized` per iteration, so a dead id is dropped from the in-memory hash while every other id still flows into the `repo-details` insert loop. The downstream `repos.each do |id, json|` body is untouched.

Test plan: `bundle exec rake` runs cleanly (24 unit tests + 16 judges tests, RuboCop clean). A new `judges/copy-repo-names/skips-missing-repo.yml` fixture mixes a valid id (`12345`) with the `FakeOctokit` 404 id (`404123`) and asserts that `repo-details` is inserted for the valid id while no `repo-details` row appears for the 404 id; that fixture passes under the new rescue and would crash under the previous `to_h` line.

Fixes #601
