### PR TITLE
#608: gate --verbose/GLI_DEBUG on INPUT_VERBOSE matching 'true'

### DIFF
--- a/entries/verbose-false-skips-detailed-logs.sh
+++ b/entries/verbose-false-skips-detailed-logs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+SELF=$1
+
+BUNDLE_GEMFILE="${SELF}/Gemfile"
+export BUNDLE_GEMFILE
+bundle exec judges eval test.fb "\$fb.insert" > /dev/null
+
+env "GITHUB_WORKSPACE=$(pwd)" \
+  'INPUT_FACTBASE=test.fb' \
+  'INPUT_OUTPUT=output' \
+  'INPUT_VERBOSE=false' \
+  "${SELF}/entry.sh" 2>&1 | tee log.txt
+
+grep "Since 'verbose' is not set to 'true', you won't see detailed logs" log.txt

--- a/entry.sh
+++ b/entry.sh
@@ -77,7 +77,7 @@ else
 fi
 
 declare -a gopts=()
-if [ -n "${INPUT_VERBOSE}" ]; then
+if [ "${INPUT_VERBOSE}" == 'true' ]; then
     gopts+=("--verbose")
     export GLI_DEBUG=true
 else


### PR DESCRIPTION
Issue #608 reported that `entry.sh:80` used `if [ -n "${INPUT_VERBOSE}" ]` for the `--verbose`/`GLI_DEBUG` branch, so the action took the verbose path on every run including the documented default `INPUT_VERBOSE=false`. The same script already gates `set -x` on the correct condition at line 26 (`if [ "${INPUT_VERBOSE}" == 'true' ]`), and the `else` echo on line 84 already states the intended contract.

This change rewrites line 80 to match line 26. With the new condition, `--verbose` and `GLI_DEBUG=true` are only set when the caller passes `INPUT_VERBOSE=true`, the line 84 echo fires on every other value, and the CI log volume on default-config consumers drops to the documented level. No other code path or `INPUT_*` reading is touched.

`bash -n entry.sh entries/verbose-false-skips-detailed-logs.sh` parses cleanly on the working tree. The new `entries/verbose-false-skips-detailed-logs.sh` invokes `entry.sh` with `INPUT_VERBOSE=false` and asserts that the line 84 echo appears in the log; the same `grep` fails under the previous `-n` condition because the else branch never ran with a non-empty string. The repository's `bashate`, `shellcheck`, `make`, and entry tests run on CI for the rest of the surface area.

Closes #608