### PR TITLE
#610: refresh latest assessment fact

### DIFF
--- a/judges/latest-assessment/latest-assessment.rb
+++ b/judges/latest-assessment/latest-assessment.rb
@@ -5,12 +5,12 @@
 
 require 'fbe/fb'
 
-return unless Fbe.fb.query('(eq what "latest-assessment")').each.to_a.empty?
-
 assessments = Fbe.fb.query('(and (eq what "assessment") (exists text) (exists when))').each.to_a
 return if assessments.empty?
 
 latest = assessments.max_by(&:when)
+
+Fbe.fb.query('(eq what "latest-assessment")').delete!
 
 f = Fbe.fb.insert
 f.what = 'latest-assessment'

--- a/judges/latest-assessment/refreshes-stale.yml
+++ b/judges/latest-assessment/refreshes-stale.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  -
+    what: latest-assessment
+    when: 2024-07-01T08:00:00.000Z
+    text: Stale assessment.
+    total: 1
+  -
+    what: assessment
+    when: 2024-07-01T08:00:00.000Z
+    text: Older assessment.
+  -
+    what: assessment
+    when: 2024-10-01T10:00:00.000Z
+    text: Refreshed assessment.
+expected:
+  - /fb[count(f)=3]
+  - /fb/f[what='latest-assessment' and total=2]
+  - /fb/f[what='latest-assessment' and text='Refreshed assessment.']


### PR DESCRIPTION
Closes #610

Summary:
- Remove the early return that froze `latest-assessment` after its first insert.
- Delete any stale `latest-assessment` fact before inserting the refreshed latest assessment.
- Add a regression fixture that pre-seeds a stale latest fact and a newer assessment.

Validation:
- `docker run --rm -v "$PWD":/work -v /tmp/pages-action-bundle:/usr/local/bundle -w /work ruby:4.0 bash -lc 'bundle install >/dev/null && bundle exec judges --verbose test --disable live --no-log judges && bundle exec rubocop judges/latest-assessment/latest-assessment.rb'`\n  - `All 6 judge(s) and 16 tests passed`\n  - `1 file inspected, no offenses detected`\n- `docker run --rm -v "$PWD":/work -v /tmp/pages-action-bundle:/usr/local/bundle -w /work ruby:4.0 bash -lc 'bundle install >/dev/null && bundle exec rubocop'`\n  - `14 files inspected, no offenses detected`\n- `git diff --check`\n- `git diff -- judges/latest-assessment/latest-assessment.rb judges/latest-assessment/refreshes-stale.yml | gitleaks stdin --no-banner --redact --exit-code 1`\n  - `no leaks found`\n\nNo secrets or live service access used.