### PR TITLE
#601: skip inaccessible repositories

### DIFF
--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -10,7 +10,16 @@ known = Fbe.fb.query('(eq what "repo-details")').each.filter_map(&:repository).t
 ids = Fbe.fb.query('(exists repository)').each.map(&:repository).uniq - known
 return if ids.empty?
 
-repos = ids.to_h { |id| [id, Fbe.octo.repository(id)] }
+repos =
+  ids.filter_map do |id|
+    [id, Fbe.octo.repository(id)]
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.warn("GitHub repository ##{id} is absent: #{e.class}: #{e.message}")
+    nil
+  rescue Octokit::Unauthorized, Octokit::Forbidden => e
+    $loog.warn("GitHub repository ##{id} is not accessible: #{e.class}: #{e.message}")
+    nil
+  end.to_h
 
 repos.each do |id, json|
   d = Fbe.fb.insert

--- a/judges/copy-repo-names/skips-absent-repo.yml
+++ b/judges/copy-repo-names/skips-absent-repo.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    what: award
+    repository: 404123
+    where: github
+  -
+    what: award
+    repository: 12345
+    where: github
+expected:
+  - /fb/f[what='repo-details' and repository='12345']
+  - /fb[count(f[what='repo-details' and repository='404123'])=0]


### PR DESCRIPTION
Fixes #601.

## Summary
- Skip repository IDs whose GitHub repository lookup returns missing, deprecated, unauthorized, or forbidden responses.
- Continue inserting `repo-details` for the remaining accessible repositories.
- Add a judge fixture using the FBE fake `404123` missing-repo ID to cover the skip-and-continue behavior.

## Validation
- Pre-fix local reproduction: `Octokit::NotFound` from repo ID `404123` aborted the judge with `repo_details=0`.
- Post-fix local reproduction: no exception, `repo_details=1 repos=12345`.
- `bundle exec judges --verbose test --disable live --no-log judges`
- `bundle exec rubocop`
- `make target/saxon.jar && bundle exec rake` -> 24 tests, 47 assertions, 0 failures, 0 errors, 2 skips; 6 judges and 16 judge fixtures; RuboCop clean.
- `git diff --check`
- `gitleaks protect --staged --no-banner --redact --verbose`
