### PR TITLE
#601: skip inaccessible repositories

### DIFF
--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -10,7 +10,16 @@ known = Fbe.fb.query('(eq what "repo-details")').each.filter_map(&:repository).t
 ids = Fbe.fb.query('(exists repository)').each.map(&:repository).uniq - known
 return if ids.empty?
 
-repos = ids.to_h { |id| [id, Fbe.octo.repository(id)] }
+repos =
+  ids.filter_map do |id|
+    [id, Fbe.octo.repository(id)]
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.warn("GitHub repository ##{id} is absent: #{e.class}: #{e.message}")
+    nil
+  rescue Octokit::Unauthorized, Octokit::Forbidden => e
+    $loog.warn("GitHub repository ##{id} is not accessible: #{e.class}: #{e.message}")
+    nil
+  end.to_h
 
 repos.each do |id, json|
   d = Fbe.fb.insert

--- a/judges/copy-repo-names/skips-absent-repo.yml
+++ b/judges/copy-repo-names/skips-absent-repo.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    what: award
+    repository: 404123
+    where: github
+  -
+    what: award
+    repository: 12345
+    where: github
+expected:
+  - /fb/f[what='repo-details' and repository='12345']
+  - /fb[count(f[what='repo-details' and repository='404123'])=0]


### PR DESCRIPTION
Closes #601.

This keeps `copy-repo-names` from aborting the whole judge when one repository id is deleted or inaccessible. It skips that id, logs the Octokit class/message, and still writes `repo-details` for reachable repositories.

Validation:
- `env BUNDLE_PATH=/private/tmp/bundle-pages-action-601 mise x ruby@3.3.11 -- bundle exec judges --verbose test --disable live --no-log --judge copy-repo-names judges` -> all 1 judge and 3 tests passed.
- `env BUNDLE_PATH=/private/tmp/bundle-pages-action-601 mise x ruby@3.3.11 -- bundle exec rake judges` -> all 6 judges and 16 tests passed.
- `env BUNDLE_PATH=/private/tmp/bundle-pages-action-601 mise x ruby@3.3.11 java@temurin-21.0.11+10.0.LTS -- bundle exec rake test` -> 24 tests, 45 assertions, 0 failures, 0 errors, 3 skips.
- `env BUNDLE_PATH=/private/tmp/bundle-pages-action-601 mise x ruby@3.3.11 -- bundle exec rubocop judges/copy-repo-names/copy-repo-names.rb --format simple` -> 1 file inspected, no offenses.
- `env BUNDLE_PATH=/private/tmp/bundle-pages-action-601 mise x ruby@3.3.11 -- bundle exec ruby -c judges/copy-repo-names/copy-repo-names.rb` -> Syntax OK.
- `git diff --check origin/master...HEAD` -> passed.
- `git diff origin/master...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

I did not run the full Docker-backed `make` target locally.