### PR TITLE
#618: log the badge SVG path instead of the rich.xml input

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -239,11 +239,11 @@ java -jar "${SELF}/target/saxon.jar" \
 html-minifier "${html}" --config-file "${SELF}/html-minifier-config.json" -o "${html}"
 echo "HTML generated at: ${html}"
 
-svg=${INPUT_OUTPUT}/${name}.rich.xml
+svg=${INPUT_OUTPUT}/${name}-badge.svg
 java -jar "${SELF}/target/saxon.jar" \
-    "-s:${svg}" \
+    "-s:${INPUT_OUTPUT}/${name}.rich.xml" \
     "-xsl:${SELF}/target/xsl/badge.xsl" \
-    "-o:${INPUT_OUTPUT}/${name}-badge.svg" \
+    "-o:${svg}" \
     "today=${INPUT_TODAY}"
 echo "SVG badge generated at: ${svg}"
 


### PR DESCRIPTION
Issue #618 pointed at `entry.sh:248`, which logged `SVG badge generated at: ${svg}`. Line 242 had set `svg` to `${INPUT_OUTPUT}/${name}.rich.xml` — the input the badge transform consumes — and line 250 removes that file immediately after, so the log line guided readers to a path that no longer existed.

This swaps the assignment so `svg` now names the `-o:` target `${INPUT_OUTPUT}/${name}-badge.svg`, then feeds the literal `${INPUT_OUTPUT}/${name}.rich.xml` into `-s:`. The badge transform and the cleanup `rm` are untouched, and the log now prints the artifact users can open.

Local checks on the changed file: `bash -n entry.sh` clean, `shellcheck entry.sh` clean, `bashate -i E006,E003 entry.sh` clean (matches the rule used in `.github/workflows/bashate.yml`). The full Docker-based `make` was not run locally; CI on this branch will exercise it.

Closes #618
