### PR TITLE
#619: align entry.sh fallback timeout/lifetime with action.yml defaults

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -137,14 +137,14 @@ fi
 
 timeout=${INPUT_TIMEOUT}
 if [ -z "${timeout}" ]; then
-    timeout=10
+    timeout=3
 fi
 timeout=$((timeout * 60))
 echo "Each judge will spend up to ${timeout} seconds"
 
 lifetime=${INPUT_LIFETIME}
 if [ -z "${lifetime}" ]; then
-    lifetime=15
+    lifetime=5
 fi
 lifetime=$((lifetime * 60))
 echo "The update will run for up to ${lifetime} seconds"


### PR DESCRIPTION
The empty-input fallbacks in `entry.sh:140` and `entry.sh:147` set `timeout=10` and `lifetime=15`, while `action.yml` declares `default: 3` and `default: 5` for the same inputs. Inside GitHub Actions the declared defaults always populate `INPUT_TIMEOUT` and `INPUT_LIFETIME`, so the disagreement is invisible, but `make` runs and any direct `entry.sh` invocation silently grant the judge roughly 3x more wall time than the manifest promises.

This aligns the two fallbacks with `action.yml`, so the manifest remains the single source of truth for the documented defaults. The `Each judge will spend up to ${timeout} seconds` line now prints `180` (not `600`) and the lifetime line prints `300` (not `900`) when both inputs are empty. No call sites change; the values only differ from before when the script runs outside Actions with both inputs unset.

Local checks on the touched file: `bash -n entry.sh` clean, `shellcheck entry.sh` clean, `bashate -i E006,E003 entry.sh` clean (matches the rule used in `.github/workflows/bashate.yml`). The full Docker-based `make` was not run locally; CI on this branch will exercise it.

Closes #619
