### PR TITLE
#621: bump nodesource setup to setup_24.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -y --fix-missing \
 
 # hadolint ignore=DL3008
 RUN rm -rf /usr/lib/node_modules \
-  && curl -sL -o /tmp/nodesource_setup.sh https://deb.nodesource.com/setup_18.x \
+  && curl -sL -o /tmp/nodesource_setup.sh https://deb.nodesource.com/setup_24.x \
   && bash /tmp/nodesource_setup.sh \
   && apt-get update -y --fix-missing \
   && apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Replace the Node.js 18 NodeSource setup script with Node 24 in the Dockerfile. Node.js 18 reached EOL on 2025-04-30 and the published image was running every action against an unmaintained runtime.

The change aligns the runtime with what CI tests against: `.github/workflows/make.yml` already provisions `node-version: 24` via `actions/setup-node@v6`, so the image now matches the workflow.

Verified with hadolint 2.12.0 against the modified Dockerfile — clean, no warnings. The full build runs in CI on push.

Closes #621