### PR TITLE
#627: prevent GitHub token leak in verbose mode

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -130,7 +130,9 @@ if [ "${github_token_found}" == "false" ]; then
         echo "The 'github-token' plugin parameter is not set (\$INPUT_GITHUB-TOKEN is empty)"
     else
         echo "The 'github-token' plugin parameter is set, using it"
+        set +x
         options+=("--option=github_token=$(printenv "INPUT_GITHUB-TOKEN")");
+        [ "${INPUT_VERBOSE}" == 'true' ] && set -x
         github_token_found=true
     fi
 fi


### PR DESCRIPTION
When `INPUT_VERBOSE=true`, `set -x` traces every command including the GitHub token interpolation at `entry.sh:133`:

```bash
options+=("--option=github_token=$(printenv "INPUT_GITHUB-TOKEN")");
```

This leaks the token into the action log.

**Fix:** wrap the sensitive line with `set +x` / `set -x` guards so the expanded token is never traced:

```bash
set +x
options+=("--option=github_token=$(printenv "INPUT_GITHUB-TOKEN")");
[ "${INPUT_VERBOSE}" == 'true' ] && set -x
```

Fixes #627.