### PR TITLE
#633: use pinned reviewdog/action-actionlint instead of curl | bash

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,10 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        run: ${{ steps.get_actionlint.outputs.executable }} -color
-        shell: bash
+      - uses: reviewdog/action-actionlint@v1.72.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `actionlint` workflow downloaded and executed a script via `curl | bash` with no integrity verification:

```yaml
run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
```

This is a supply-chain risk — if the upstream repo is compromised, arbitrary code runs in CI.

**Fix:** replace with `reviewdog/action-actionlint@v1.72.0`, a maintained GitHub Action pinned to a specific version.

Fixes #633.