### PR TITLE
#629: switch rubygems source to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'factbase', '~>0.17'
 gem 'fbe', '~>0.41'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (8.1.3)
       base64


### PR DESCRIPTION
`Gemfile:6` and `Gemfile.lock:2` declared the rubygems source as `http://rubygems.org`, leaving `bundle install` open to a network-level man-in-the-middle. This change rewrites both to `https://rubygems.org`, which is the standard transport rubygems.org has documented for years.

Visible effect: no behavior change for a healthy network; `bundle install` now refuses a tampered response served from an intermediary instead of trusting it.

Verified locally with `bundle install --jobs 4` against the new `https` source — `Bundle complete! 18 Gemfile dependencies, 96 gems now installed`, no resolver changes, and `Gemfile.lock` remains untouched beyond the `remote:` line. CI on the branch covers the rest.

Closes #629