### PR TITLE
#629: use https://rubygems.org instead of http://

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'factbase', '~>0.17'
 gem 'fbe', '~>0.41'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (8.1.3)
       base64


### PR DESCRIPTION
The `Gemfile` declared the rubygems source with plain HTTP:

```ruby
source 'http://rubygems.org'
```

This makes `bundle install` vulnerable to MITM attacks. The `Gemfile.lock` had the same issue.

**Fix:** change to `https://rubygems.org` and regenerate `Gemfile.lock` via `bundle install`.

Fixes #629.