### PR TITLE
#635: use cd && pwd instead of realpath for macOS compatibility

### DIFF
--- a/makes/entry-in-docker.sh
+++ b/makes/entry-in-docker.sh
@@ -10,7 +10,7 @@ test -e target/fb/simple.fb
 
 docker run --rm \
     "--user=$(id -u):$(id -g)" \
-    -v "$(realpath "$(pwd)")/target/fb/:/work" \
+    -v "$(cd "$(pwd)" && pwd)/target/fb/:/work" \
     -e GITHUB_WORKSPACE=/work \
     -e INPUT_FACTBASE=simple.fb \
     -e INPUT_VERBOSE=true \


### PR DESCRIPTION
`makes/entry-in-docker.sh:13` used `realpath "$(pwd)"` which is a GNU utility not available on macOS by default, breaking `make` for macOS developers.

**Fix:** replace with POSIX-compatible `cd "$(pwd)" && pwd`.

Fixes #635.