### PR TITLE
#634: fix implicit global variable and unhandled Promise in clipboard.js

### DIFF
--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -9,7 +9,9 @@ $(() => {
       text = $this.attr('data-text');
     if (navigator.clipboard) {
       if (window.isSecureContext) {
-        navigator.clipboard.writeText(text);
+        navigator.clipboard.writeText(text).catch(() => {
+          alert('Failed to copy to clipboard!');
+        });
       } else {
         alert('Cannot copy to clipboard!');
         return false;
@@ -18,7 +20,7 @@ $(() => {
       alert('The clipboard is inaccessible!');
       return false;
     }
-    $check = $('<span class="darkgreen"> ✓</span>');
+    const $check = $('<span class="darkgreen"> ✓</span>');
     $this.after($check);
     $check.delay(1000).fadeOut();
     return false;


### PR DESCRIPTION
Two issues in `js/clipboard.js`:

1. **Implicit global**: `$check` at line 21 was assigned without `const`/`let`, leaking into `window.$check` and causing race conditions on rapid clicks.

2. **Unhandled Promise**: `navigator.clipboard.writeText()` returns a Promise that was silently ignored. If the clipboard write is rejected, the error goes unnoticed.

**Fix:** add `const` to `$check` and chain `.catch()` on the Promise.

Fixes #634.