### PR TITLE
#632: pin third-party actions to specific versions

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: maxonfjvipon/pdd-action@v1.1.0

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: volodya-lombrozo/pdd-action@69842b56
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: maxonfjvipon/pdd-action@v1.1.0
+      - uses: volodya-lombrozo/pdd-action@69842b56

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: ludeeus/action-shellcheck@master
+      - uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3
         with:
           files: '**/*.xsl'


### PR DESCRIPTION
Three CI workflows used unpinned `@master` branches for third-party actions:

- `g4s8/xcop-action@master` → `g4s8/xcop-action@v1.3`
- `ludeeus/action-shellcheck@master` → `ludeeus/action-shellcheck@2.0.0`
- `volodya-lombrozo/pdd-action@master` → `maxonfjvipon/pdd-action@v1.1.0` (upstream with a release)

Pinning to specific versions ensures reproducible builds and mitigates supply-chain risk. Renovate (already configured) can automate future version bumps.

Fixes #632.