### PR TITLE
#636: split CSS integrity links at final pipe

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -88,6 +88,23 @@ class TestVitals < Minitest::Test
     assert_includes(css, '@media(max-width:768px){.bylaws.columns{column-count:1}}', 'Phone layout broken')
   end
 
+  def test_css_links_allow_pipe_in_url
+    xml = xslt(
+      <<~XSL,
+        <r>
+          <xsl:call-template name="css-links">
+            <xsl:with-param name="links" select="'https://cdn.example.com/app.css?next=a|b|abc123'"/>
+          </xsl:call-template>
+        </r>
+      XSL
+      '<fb/>'
+    )
+    link = xml.xpath('/r/link').first
+    refute_nil(link, xml)
+    assert_equal('https://cdn.example.com/app.css?next=a|b', link['href'])
+    assert_equal('sha384-abc123', link['integrity'])
+  end
+
   private
 
   def generate_vitals_html

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -107,11 +107,12 @@
     <xsl:param name="links"/>
     <xsl:variable name="lines" select="tokenize($links, '\n')"/>
     <xsl:for-each select="$lines[normalize-space(.) != '']">
-      <xsl:variable name="parts" select="tokenize(., '\|')"/>
-      <xsl:if test="count($parts) = 2">
+      <xsl:variable name="url" select="replace(., '\|[^|]*$', '')"/>
+      <xsl:variable name="integrity" select="replace(., '^.*\|', '')"/>
+      <xsl:if test="$url != . and normalize-space($integrity) != ''">
         <xsl:call-template name="css">
-          <xsl:with-param name="url" select="normalize-space($parts[1])"/>
-          <xsl:with-param name="integrity" select="normalize-space($parts[2])"/>
+          <xsl:with-param name="url" select="normalize-space($url)"/>
+          <xsl:with-param name="integrity" select="normalize-space($integrity)"/>
         </xsl:call-template>
       </xsl:if>
     </xsl:for-each>


### PR DESCRIPTION
/claim #636

Fixes #636.

## Summary
- Preserve literal `|` characters inside CSS URLs by splitting `css-links` entries at the final `|` delimiter.
- Keep malformed entries skipped when no delimiter or integrity value is present.
- Add an XSLT regression for a URL containing `|`.

## Validation
- `bundle check`
- `make target/saxon.jar`
- focused `test_css_links_allow_pipe_in_url` run -> `1 tests, 3 assertions, 0 failures, 0 errors, 0 skips`
- full `test/pages/test_vitals.rb` run -> `7 tests, 25 assertions, 0 failures, 0 errors, 1 skips`
- `xmllint --noout xsl/vitals.xsl`
- `bundle exec rubocop test/pages/test_vitals.rb`
- `git diff --check origin/master...HEAD`
- committed diff secret-pattern check -> no matches
- hosted PR checks -> all 15 passed (`actionlint`, `bashate`, `checkmake`, `copyrights`, `hadolint`, `make`, `markdown-lint`, `pdd`, `reuse`, `shellcheck`, `stylelint`, `test`, `typos`, `xcop`, `yamllint`)

No secrets, credentials, wallet, payout, KYC/tax, signing, or off-ramp actions were performed.