### PR TITLE
#640: enable recommended ESLint baseline

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,12 +3,31 @@
  * SPDX-License-Identifier: MIT
  */
 
+const js = require("@eslint/js");
+
 module.exports = [
   {
+    ignores: ["target/**/*"]
+  },
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "script",
+      globals: {
+        $: "readonly",
+        Chart: "readonly",
+        alert: "readonly",
+        console: "readonly",
+        document: "readonly",
+        navigator: "readonly",
+        setInterval: "readonly",
+        window: "readonly"
+      }
+    },
     rules: {
       semi: "error",
       "prefer-const": "error"
-    },
-    ignores: ["target/**/*"]
+    }
   }
 ];

--- a/js/qo-section.js
+++ b/js/qo-section.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+/* exported qo_render */
+
 /**
  * Render QO canvas.
  * @param canvas The ID of "canvas" element in HTML

--- a/makes/install.sh
+++ b/makes/install.sh
@@ -14,6 +14,7 @@ else
         apt-get install -y tidy
     fi
 fi
+npm --no-color install --no-save @eslint/js@9.22.0
 npm --no-color install -g eslint@9.22.0
 npm --no-color install -g uglify-js@3.19.3
 npm --no-color install -g sass@1.77.2


### PR DESCRIPTION
/claim #640

Closes #640.

Changes:
- Enable the `@eslint/js` recommended flat-config baseline while keeping the existing `semi` and `prefer-const` rules.
- Declare the browser/script globals used by the generated page JavaScript (`$`, `Chart`, `document`, `navigator`, etc.) so `no-undef` can catch real leaks.
- Install local `@eslint/js@9.22.0` during `make install`, since this repository runs a global ESLint binary without a local package manifest.
- Mark `qo_render` as an exported script global because generated HTML calls it.

Validation:
- `npm --no-color install --no-save @eslint/js@9.22.0 uglify-js@3.19.3 sass@1.77.2 stylelint@16.15.0 stylelint-config-standard@37.0.0 stylelint-scss@6.11.1`
- `PATH=./node_modules/.bin:$PATH eslint js/*.js`
- `PATH=./node_modules/.bin:$PATH stylelint sass/*.scss`
- `PATH=./node_modules/.bin:$PATH make assets`
- `bash -n makes/install.sh`
- `git diff --check`
- diff secret-pattern scan -> no matches

Local note: `bashate`, `reuse`, `yamllint`, and `shellcheck` are not installed in this workspace, so I left those to hosted CI. No secrets, credentials, wallet, payout, or live-service testing was used.
