### PR TITLE
#623: plumb release version into Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,12 @@ jobs:
             f.days_of_running_balance = 28; \
             "
       - run: |
-          docker build -t pages-action:test .
+          docker build --build-arg VERSION=0.0.1 -t pages-action:test .
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             -v "$(pwd):/github/workspace" \
             -e GITHUB_WORKSPACE=/github/workspace \
+            -e LATEST_VERSION=0.0.1 \
             -e INPUT_VERBOSE=true \
             -e INPUT_OUTPUT=pages \
             -e INPUT_FACTBASE=test.fb \
@@ -41,4 +42,7 @@ jobs:
             -e INPUT_HIGHLIGHTED=stale,tombstone \
             -e INPUT_HIDDEN=_id,_time,_version \
             pages-action:test
-      - run: test -f pages/test.html && test -f pages/test-vitals.html
+      - run: |
+          test -f pages/test.html
+          test -f pages/test-vitals.html
+          grep '0.0.1' pages/test-vitals.html

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -17,17 +17,13 @@ release:
   pre: false
   script: |-
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
-    sed -i -e "s/0.0.0/${tag}/" entry.sh
-    sed -i -e "s/0.0.0/${tag}/" Dockerfile
     sed -i -e "s/:latest/:${tag}/" action.yml
-    git add entry.sh
-    git add Dockerfile
     git add action.yml
     git commit -m "version set to ${tag}"
-    sudo make -C "$(pwd)" target/html/simple.html
+    sudo make -C "$(pwd)" "PAGES_ACTION_VERSION=${tag}" target/html/simple.html
     repo=yegor256/pages-action
-    sudo docker build "$(pwd)" --tag "${repo}:${tag}"
-    sudo docker build "$(pwd)" --tag "${repo}:latest"
+    sudo docker build "$(pwd)" --build-arg "VERSION=${tag}" --tag "${repo}:${tag}"
+    sudo docker build "$(pwd)" --build-arg "VERSION=${tag}" --tag "${repo}:latest"
     cat ../docker-password | sudo docker login --password-stdin -u yegor256
     sudo docker push "${repo}:${tag}"
     sudo docker push "${repo}:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@
 
 FROM ruby:4.0
 
+ARG VERSION=0.0.0
+ENV PAGES_ACTION_VERSION="${VERSION}"
+
 LABEL "repository"="https://github.com/zerocracy/pages-action"
 LABEL "maintainer"="Yegor Bugayenko"
-LABEL "version"="0.0.0"
+LABEL "version"="${VERSION}"
 
 # hadolint ignore=DL3008
 RUN apt-get update -y --fix-missing \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CSS = target/css/main.css
 JS = target/js/main.js
 JS_TEST = target/js/test.js
 SAXON = target/saxon.jar
+PAGES_ACTION_VERSION ?= 0.0.0
 
 export
 
@@ -114,8 +115,8 @@ verify:
 
 target/docker-image.txt: Makefile Dockerfile entry.sh
 	mkdir -p "$$(dirname $@)"
-	docker build -t pages-action "$$(pwd)"
-	docker build -t pages-action -q "$$(pwd)" > "$@"
+	docker build --build-arg "VERSION=$(PAGES_ACTION_VERSION)" -t pages-action "$$(pwd)"
+	docker build --build-arg "VERSION=$(PAGES_ACTION_VERSION)" -t pages-action -q "$$(pwd)" > "$@"
 
 $(DIRS):
 	mkdir -p "$@"

--- a/entries/renders-no-version-mismatch.sh
+++ b/entries/renders-no-version-mismatch.sh
@@ -19,9 +19,12 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_LOGO=' \
   'INPUT_ADLESS=true' \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
-  'LATEST_VERSION=0.0.0' \
+  'PAGES_ACTION_VERSION=0.0.1' \
+  'LATEST_VERSION=0.0.1' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
+grep "The 'pages-action' 0.0.1 is running" 'log.txt'
+grep "0.0.1" 'output/test-vitals.html'
 if grep -q "while the latest version is" 'output/test-vitals.html'; then
     echo "ERROR: Warning banner should not appear when versions match"
     exit 1

--- a/entry.sh
+++ b/entry.sh
@@ -4,7 +4,7 @@
 
 set -e -o pipefail
 
-VERSION=0.0.0
+VERSION="${PAGES_ACTION_VERSION:-0.0.0}"
 
 echo "Checking for the latest version of zerocracy/pages-action..."
 


### PR DESCRIPTION
/claim #623

Closes #623.

Changes:
- Add a Docker `VERSION` build arg and expose it as `PAGES_ACTION_VERSION` inside the image.
- Make `entry.sh` use `PAGES_ACTION_VERSION` for the runtime banner and `vitals.xsl` `version` parameter, falling back to `0.0.0` for local source runs.
- Update the Rultor release script to pass the release tag as the Docker build arg instead of rewriting `entry.sh` and `Dockerfile` source files.
- Exercise the version plumbing in the Docker CI workflow and the no-version-mismatch entry scenario.

Validation:
- `bash -n entry.sh entries/renders-no-version-mismatch.sh makes/entry-in-docker.sh` -> passed
- `bundle check` -> passed
- `PATH=/tmp/pages-action-623-tools/node_modules/.bin:$PATH NODE_PATH=/tmp/pages-action-623-tools/node_modules make assets` -> passed
- `PATH=/tmp/pages-action-623-tools/node_modules/.bin:$PATH NODE_PATH=/tmp/pages-action-623-tools/node_modules make entries` -> passed
- `docker build --build-arg VERSION=9.8.7 -t pages-action:623-version .` -> passed
- `docker image inspect pages-action:623-version --format ...` -> label `version=9.8.7`, env `PAGES_ACTION_VERSION=9.8.7`
- `docker run --rm -e LATEST_VERSION=9.8.7 pages-action:623-version /home` -> printed `The 'pages-action' 9.8.7 is running` before the expected non-GitHub-workspace exit
- `PAGES_ACTION_VERSION=0.0.1 LATEST_VERSION=0.0.1 make target/html/simple.html` -> completed; generated vitals contained `0.0.1` and no latest-version mismatch banner
- `git diff --check` -> passed
- diff secret-pattern scan -> no matches

Local note: the first `make install` attempt failed after Bundler and some npm setup because this workspace already has an old `/usr/local/bin/sass` Ruby Sass binary, causing npm global `sass@1.77.2` to hit `EEXIST`. I used a temporary Node prefix under `/tmp/pages-action-623-tools` for the asset and entry validations. `tidy` is also not installed locally, so the focused HTML target printed `tidy: command not found`; the Makefile did not fail on that exit status, and XPath checks plus direct version/no-warning greps passed. No secrets, credentials, wallet, payout, or live-service testing was used.