### PR TITLE
#652: document missing action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ to print in the HTML;
 * `highlighted` (optional) is a comma-separated list of columns to highlight;
 * `hidden` (optional) is a comma-separated list of columns to hide;
 * `today` (optional) is ISO-8601 date-time of today;
+* `timeout` (default: `3`) is the maximum number of minutes each judge may run;
+* `lifetime` (default: `5`) is the maximum number of minutes for the entire
+`judges update` run;
+* `url` (optional) is where the static files will be visible. If omitted, it is
+derived from `GITHUB_REPOSITORY_OWNER` and `GITHUB_REPOSITORY` as a GitHub Pages
+URL;
 * `verbose` (default: `false`) turns on a more detailed logging.
 * `adless` (default: `false`) hides all Zerocracy banners, links, and logos
 * `github-token` (optional) is the GitHub token, defaulted to repo-scoped token


### PR DESCRIPTION
/claim #652

Closes #652.

Summary:
- Document the existing `timeout` and `lifetime` inputs with their minute-based defaults.
- Document the existing `url` input and its derived GitHub Pages fallback.
- Keep runtime behavior unchanged.

Validation:
- `git diff --check` passed.
- `ruby -e ...` read `action.yml` and printed `timeout=3`, `lifetime=5`, `url=`.
- `bash -n entry.sh` passed.
- `npx --yes markdownlint-cli2 README.md` passed with `0 error(s)`.

No secrets or credentials are included.