### PR TITLE
Make palette.css loading conditional on adless

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -209,8 +209,10 @@ echo "Calculating integrity hashes for CSS files..."
 declare -a css_urls=(
     "https://cdn.jsdelivr.net/npm/tacit-css@1.9.5/dist/tacit-css.min.css"
     "https://cdn.jsdelivr.net/npm/drops@0.3.2/dist/drops-0.3.2.min.css"
-    "https://www.zerocracy.com/css/palette.css"
 )
+if [ "${INPUT_ADLESS}" != 'true' ]; then
+    css_urls+=("https://www.zerocracy.com/css/palette.css")
+fi
 css_links=""
 for css in "${css_urls[@]}"; do
     echo "Calculating hash for: ${css}"


### PR DESCRIPTION
## Description

Instead of the complex and conflicting PR #461 (which added a hardcoded link in XSLT with invalid syntax), this PR makes palette.css loading conditional at the entry.sh level.

## Changes

- entry.sh: palette.css from zerocracy.com is only fetched when INPUT_ADLESS != true
- When adless=true (no Zerocracy mentions), the external Zerocracy CSS file is not requested

## Motivation

PR #461 is 284 commits behind master, contains invalid XSLT syntax (xsl:if='true' — parsing error), and has merge conflicts. In current master, palette.css is already loaded via css-links. The only missing piece was conditional loading based on adless.

Closes #461