### PR TITLE
#659: accept StandardError in test_fn_format_signed_invalid_formats

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -73,7 +73,7 @@ class TestVitals < Minitest::Test
 
   def test_fn_format_signed_invalid_formats
     ['0', '0.000', '0.0000', 'invalid'].each do |invalid_format|
-      assert_raises(RuntimeError) do
+      assert_raises(StandardError) do
         xslt("<r><xsl:value-of select=\"z:format-signed(1.0, '#{invalid_format}')\"/></r>", '<fb/>')
       end
     end


### PR DESCRIPTION
The vitals test `test_fn_format_signed_invalid_formats` asserts that `xslt` raises `RuntimeError` when given an invalid format string, but qbash 0.8.4 changed the class of the exception it raises from `RuntimeError` to `StandardError`. Renovate's bump to 0.8.4 (PR #606) failed CI for exactly this reason, and the Gemfile.lock pin to 0.8.3 is the only thing keeping the suite green today. The test should accept the broader parent class so the assertion stays correct on both qbash 0.8.3 and 0.8.4+.

The change is a one-line edit in `test/pages/test_vitals.rb`: the `assert_raises(RuntimeError)` block becomes `assert_raises(StandardError)`. Because `RuntimeError < StandardError`, the assertion still matches the exception raised by qbash 0.8.3, and it now also matches the `StandardError` raised by qbash 0.8.4+. Nothing else in the test or in the production code needs to move.

Verified locally with `bundle exec ruby -Ilib -Itest test/pages/test_vitals.rb -n test_fn_format_signed_invalid_formats`, which passed (1 test, 4 assertions, 0 failures). The other tests in the file require `target/saxon.jar`, which is not built in this environment, so the broader `make` run was not exercised locally and is left to CI.

Closes #659