### PR TITLE
#665: regenerate bylaws fact instead of guarding on its presence

### DIFF
--- a/judges/add-bylaws-html/add-bylaws-html.rb
+++ b/judges/add-bylaws-html/add-bylaws-html.rb
@@ -7,8 +7,6 @@ require 'fbe/award'
 require 'fbe/fb'
 require 'redcarpet'
 
-return unless Fbe.fb.query('(eq what "bylaws")').each.to_a.empty?
-
 f = Fbe.fb.query('(and (eq what "pmp") (eq area "hr"))').each.to_a.first
 htmls = []
 par = 1
@@ -20,6 +18,8 @@ f&.all_properties&.each do |prop|
   htmls << Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(md)
   par += 1
 end
+Fbe.fb.query('(eq what "bylaws")').delete!
+return if htmls.empty?
 s = Fbe.fb.insert
 s.what = 'bylaws'
-s.html = htmls.join unless htmls.empty?
+s.html = htmls.join

--- a/judges/add-bylaws-html/no-policy.yml
+++ b/judges/add-bylaws-html/no-policy.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  -
+    what: something
+    where: github
+expected:
+  - /fb[count(f)=1]
+  - /fb[count(f[what='bylaws'])=0]

--- a/judges/add-bylaws-html/refreshes-stale.yml
+++ b/judges/add-bylaws-html/refreshes-stale.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  -
+    what: bylaws
+  -
+    what: pmp
+    area: hr
+    abc: '(award (let x 25) (give x "when you deserve it"))'
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='bylaws' and html]


### PR DESCRIPTION
Fixes #665

`judges/add-bylaws-html/add-bylaws-html.rb` previously guarded on the presence of a `bylaws` fact and unconditionally inserted one even when the `pmp/hr` policy was missing. The empty fact then satisfied the guard on every later run, so the bylaws HTML never appeared in the vitals page once the policy was added.

This patch drops the early-return, deletes any prior `bylaws` fact, runs the existing markdown-to-HTML loop, and only inserts a new `bylaws` fact when `htmls` is non-empty. The shape mirrors `judges/latest-assessment/latest-assessment.rb`, which already follows the same delete-then-rebuild pattern. Two new judge fixtures cover the previously untested paths: `no-policy.yml` asserts that no `bylaws` fact is inserted when the `pmp/hr` fact is absent, and `refreshes-stale.yml` asserts that a stale empty `bylaws` fact from a prior buggy run is deleted and replaced once the policy is present.

Verified locally with `bundle exec judges --verbose test --no-log judges` (19 tests pass, including the two new ones) and `bundle exec rake test` (25 tests pass) after building `target/saxon.jar`. `bundle exec rubocop judges/add-bylaws-html/add-bylaws-html.rb` reports no offenses.

---
_Generated by [Claude Code](https://claude.ai/code)_