### PR TITLE
#673: fix copyright holder in REUSE.toml and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
 .bundle/

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
 version = 1
@@ -26,5 +26,5 @@ path = [
     "renovate.json",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"
+SPDX-FileCopyrightText = "Copyright (c) 2024-2026 Zerocracy"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## What happens

`REUSE.toml` at the repository root contradicts the project ownership in two
places: the header comment (lines 1-2) and the override block's
`SPDX-FileCopyrightText` (line 29) both read `Copyright (c) 2025 Yegor
Bugayenko`. The override block applies to every path matched by its `path`
array (`**/.gitignore`, `**/*.json`, `**/*.md`, `**/*.txt`, `**/*.svg`,
`Gemfile.lock`, `README.md`, `renovate.json`, etc.) with `precedence =
"override"`, making REUSE.toml the authoritative source for those files'
attribution.

The local `.gitignore` carries the same stale header directly:
`# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko`.

Every other source file in the tree already uses
`SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy` — e.g.
`entry.sh:2`, `Dockerfile:1`, `Makefile:1`, `Rakefile:3`, `action.yml:1`,
`js/clipboard.js:2`, `eslint.config.js:2`. The result is that
REUSE-driven attribution reports a different copyright holder than the rest
of the codebase claims.

## What should happen

`REUSE.toml` and `.gitignore` should use the same copyright holder as the
rest of the repository: `Copyright (c) 2024-2026 Zerocracy`.

## Fix

Replaced `Copyright (c) 2025 Yegor Bugayenko` with
`Copyright (c) 2024-2026 Zerocracy` in both occurrences in `REUSE.toml`
(header comment and override block) and the one in `.gitignore`. No other
files needed changes — this matches the convention already established
across the rest of the source tree.

## Verification

Metadata-only change (SPDX headers), no logic touched — confirmed by `git
diff` showing only the copyright string replaced in the two files, and by
checking git history that the rest of the codebase already moved to the
`2024-2026 Zerocracy` holder (e.g. the "year up to 2026" commit on
`entry.sh`).

Closes #673
