### PR TITLE
#581: add SRI to CDN JS includes, pin chart.js version

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -230,6 +230,29 @@ for css in "${css_urls[@]}"; do
 done
 css_links="${css_links%$'\n'}"
 
+echo "Calculating integrity hashes for JS files..."
+declare -a js_urls=(
+    "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+    "https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"
+    "https://cdn.jsdelivr.net/npm/chart.js@4.5.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.4.2/chroma.min.js"
+)
+js_links=""
+for js in "${js_urls[@]}"; do
+    echo "Calculating hash for: ${js}"
+    hash=$(curl -sSf --max-time 30 "$js" | openssl dgst -sha384 -binary | openssl base64 -A) || {
+        echo "ERROR: Failed to fetch JS from: ${js}" >&2
+        exit 1
+    }
+    if [ -z "$hash" ]; then
+        echo "ERROR: Failed to calculate hash for: ${js}" >&2
+        exit 1
+    fi
+    echo "Hash: ${hash}"
+    js_links="${js_links}${js}|${hash}"$'\n'
+done
+js_links="${js_links%$'\n'}"
+
 java -jar "${SELF}/target/saxon.jar" \
     "-s:${INPUT_OUTPUT}/${name}.rich.xml" \
     "-xsl:${SELF}/target/xsl/vitals.xsl" \
@@ -244,6 +267,7 @@ java -jar "${SELF}/target/saxon.jar" \
     "url=${url}" \
     "adless=${INPUT_ADLESS}" \
     "css-links=${css_links}" \
+    "js-links=${js_links}" \
     "css=$(cat "${SELF}/target/css/main.css")" \
     "js=$(cat "${SELF}/${INPUT_JS_FILE:-target/js/main.js}")"
 html-minifier "${html}" --config-file "${SELF}/html-minifier-config.json" -o "${html}"

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -157,6 +157,7 @@ class TestVitals < Minitest::Test
           fbe=0.0.50
           adless=false
           css-links=
+          js-links=
           css=body{}
           js=
         ].map { |p| Shellwords.escape(p) },

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -18,6 +18,7 @@
   <xsl:param name="fbe" as="xs:string"/>
   <xsl:param name="adless" as="xs:string"/>
   <xsl:param name="css-links" as="xs:string"/>
+  <xsl:param name="js-links" as="xs:string"/>
   <xsl:import href="awards.xsl"/>
   <xsl:import href="assessment.xsl"/>
   <xsl:import href="repositories.xsl"/>
@@ -94,7 +95,8 @@
   </xsl:function>
   <xsl:template name="javascript">
     <xsl:param name="url"/>
-    <script src="{$url}">
+    <xsl:param name="integrity"/>
+    <script src="{$url}" integrity="sha384-{$integrity}" crossorigin="anonymous">
       <xsl:text> </xsl:text>
     </script>
   </xsl:template>
@@ -111,6 +113,20 @@
       <xsl:variable name="integrity" select="replace(., '^.*\|', '')"/>
       <xsl:if test="$url != . and normalize-space($integrity) != ''">
         <xsl:call-template name="css">
+          <xsl:with-param name="url" select="normalize-space($url)"/>
+          <xsl:with-param name="integrity" select="normalize-space($integrity)"/>
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+  <xsl:template name="js-links">
+    <xsl:param name="links"/>
+    <xsl:variable name="lines" select="tokenize($links, '\n')"/>
+    <xsl:for-each select="$lines[normalize-space(.) != '']">
+      <xsl:variable name="url" select="replace(., '\|[^|]*$', '')"/>
+      <xsl:variable name="integrity" select="replace(., '^.*\|', '')"/>
+      <xsl:if test="$url != . and normalize-space($integrity) != ''">
+        <xsl:call-template name="javascript">
           <xsl:with-param name="url" select="normalize-space($url)"/>
           <xsl:with-param name="integrity" select="normalize-space($integrity)"/>
         </xsl:call-template>
@@ -170,18 +186,9 @@
         <xsl:call-template name="css-links">
           <xsl:with-param name="links" select="$css-links"/>
         </xsl:call-template>
-        <xsl:for-each select="(
-          'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js',
-          'https://cdn.jsdelivr.net/npm/chart.js',
-          'https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.4.2/chroma.min.js'
-          )">
-          <xsl:call-template name="javascript">
-            <xsl:with-param name="url">
-              <xsl:value-of select="."/>
-            </xsl:with-param>
-          </xsl:call-template>
-        </xsl:for-each>
+        <xsl:call-template name="js-links">
+          <xsl:with-param name="links" select="$js-links"/>
+        </xsl:call-template>
         <xsl:call-template name="script-with-cdata">
           <xsl:with-param name="content" select="$js"/>
         </xsl:call-template>


### PR DESCRIPTION
## What happens

`xsl/vitals.xsl:172-183` renders four CDN-hosted JS includes (jQuery,
jquery.tablesorter, chart.js, chroma-js) without Subresource Integrity
(SRI) attributes. The CSS includes in the same template already use
build-time-computed `integrity="sha384-..."` hashes (`entry.sh` handles
the hashing); the JS includes don't. A CDN compromise on any of those
four hosts would silently execute on every visitor of every published
dashboard.

Additionally, `cdn.jsdelivr.net/npm/chart.js` has no version pin — it
auto-floats to whatever `latest` resolves to, so the served script can
change without any change to this repository.

(This addresses the JS-SRI finding from #581; the other findings in that
report — Docker image digest pinning, the XSS hardening pair, and the
cosmetic `$avg` type annotation — are separate, independent fixes better
shipped as their own PRs.)

## What should happen

The JS includes should carry the same SRI protection the CSS includes
already have, and `chart.js` should be pinned to a specific version like
every other CDN dependency in this file.

## Fix

Mirrored the existing CSS SRI mechanism for JS:

- `entry.sh`: added a `js_urls` array (with `chart.js` pinned to
  `@4.5.1`, the latest release) and a hashing loop that builds a
  `js-links` string in the same `url|hash` format `css-links` already
  uses
- `xsl/vitals.xsl`: added the `js-links` parameter, an `integrity`
  parameter on the `javascript` template (now emitting
  `integrity="sha384-..." crossorigin="anonymous"`), and a `js-links`
  named template mirroring `css-links`. Replaced the hardcoded 4-URL
  `xsl:for-each` with a call to the new `js-links` template.
- `test/pages/test_vitals.rb`: added the now-required `js-links=` param
  to the one test that renders the full document via Saxon directly.

**A bug found while implementing this**: the existing CSS hashing loop
computes the hash via `content=$(curl ...)` followed by
`printf "%s" "$content" | openssl dgst ...`. Bash's `$(...)` command
substitution strips trailing newlines from captured output, so if a CSS
file's raw bytes end in a newline, the computed hash silently
excludes it and no longer matches the bytes the browser actually
receives — the SRI check would then reject the resource in the browser.
This doesn't currently manifest because both CSS URLs in use happen not
to end in a newline, but it's a real latent bug, and would have
manifested immediately for the JS files being added here (`jquery.min.js`
does end in a newline). The new JS hashing loop avoids it entirely by
piping `curl` directly into `openssl` (`curl ... | openssl dgst ...`)
without an intermediate variable. I'm filing the pre-existing CSS-loop
version as a separate issue rather than fixing it in this PR, since it's
an independent bug outside this issue's scope.

## Verification

- Confirmed the new hash computation matches the raw file's hash exactly
  (compared `curl -o file && openssl dgst < file` against the pipe-based
  approach for all 4 JS URLs — identical)
- Confirmed the *old* (CSS-style) capture-then-hash approach silently
  truncates: reproduced a mismatch between the captured-string hash and
  the raw-file hash for `jquery.min.js` (which ends in a newline), using
  both SHA-384 and, independently, SHA-512 cross-checked against
  cdnjs's own published SRI hash for the file
- Verified `https://cdn.jsdelivr.net/npm/chart.js` currently resolves to
  byte-identical content as `https://cdn.jsdelivr.net/npm/chart.js@4.5.1`
  (`diff` of both responses — empty), so pinning doesn't change today's
  served content
- `bash -n entry.sh` — syntax valid
- Manually invoked Saxon directly against `xsl/vitals.xsl` with sample
  `js-links` data — confirmed `<script src=... integrity="sha384-..."
  crossorigin="anonymous">` renders correctly, and confirmed empty
  `js-links=` renders no script tags (no regressions for the updated
  test)
- `bundle exec ruby -I lib -I test test/pages/test_vitals.rb` — same
  result before and after this change (7 tests, 0 failures, 5 errors, 1
  skip; confirmed via `git stash` that the 5 errors are a pre-existing
  sandbox limitation — `/bin/bash` doesn't exist in this NixOS
  environment, unrelated to this change)
- `bundle exec rubocop test/pages/test_vitals.rb` — no offenses

Addresses the JS-SRI finding from #581 (the report bundles 5 independent
findings; this PR closes only that one, so #581 should stay open for the
rest).

