### PR TITLE
#581: pin Docker image to content digest instead of mutable :latest tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ description: 'Build static pages from a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'
 runs:
   using: 'docker'
-  image: 'docker://yegor256/pages-action:latest'
+  image: 'docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08'
 inputs:
   verbose:
     description: 'Log as much debug information as possible'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 name: 'pages-action'
 description: 'Build static pages from a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'


### PR DESCRIPTION
## What happens

`action.yml:9` pins the action's Docker image to the `:latest` tag:

```yaml
image: 'docker://yegor256/pages-action:latest'
```

A compromised Docker Hub credential (or an unintended push) that updates
`:latest` causes every consumer's next run to execute the new image with
`${{ github.token }}`, without any change to this repository or review of
the new image.

Even an exact version tag like `:0.7.0` is mutable on Docker Hub —
anyone with push access can re-tag the same name to point at a different
image, and consumers won't notice. The robust pin is by content digest,
which is the hash of the image manifest and immutable by construction —
the same principle behind pinning `uses:` in GitHub Actions workflows to
a commit SHA rather than a branch or tag.

(This addresses the Docker-digest finding from #581, a report bundling 5
independent findings; the JS-SRI finding already shipped separately in
#690.)

## What should happen

The image should be pinned to its content digest.

## Fix

```diff
-  image: 'docker://yegor256/pages-action:latest'
+  image: 'docker://yegor256/pages-action@sha256:d62ca44b6ce3d06826ea9a65dc4184bf22464d40a6667ae2f55dd8c202bbaa08'
```

Digest obtained via `docker pull yegor256/pages-action:latest` followed
by `docker inspect --format '{{index .RepoDigests 0}}'`, confirming the
manifest hash of the image currently served as `:latest`.

## A note on maintenance

Pinning to a digest means this action will keep using today's image
until the pin is bumped — it won't pick up new pushes to `:latest`
automatically. `renovate.json` here uses the `config:base` preset with no
custom manager, and I could not confirm with certainty whether Renovate's
default GitHub Actions manager tracks a `docker://...@sha256:...`
reference inside `action.yml`'s `runs.image` field the same way it
tracks `uses:` SHA pins in workflow files. If it doesn't, this pin will
need a manual bump (or a Renovate `customManagers` regex entry) whenever
`yegor256/pages-action` publishes a new image — worth confirming or
adding before merge.

## Verification

- `docker inspect yegor256/pages-action:latest --format '{{index
  .RepoDigests 0}}'` — confirms the digest matches what was pulled
- `ruby -ryaml -e "YAML.load_file('action.yml')"` — YAML valid
- No test in this repo references `action.yml`'s image field, so no test
  changes needed

Addresses the Docker-digest finding from #581 (the XSS hardening pair and
the cosmetic `$avg` annotation remain open in that report).

