### PR TITLE
#581: escape embedded raw HTML in bylaws markdown rendering

### DIFF
--- a/judges/add-bylaws-html/add-bylaws-html.rb
+++ b/judges/add-bylaws-html/add-bylaws-html.rb
@@ -15,7 +15,7 @@ f&.all_properties&.each do |prop|
   next unless q.is_a?(String)
   next unless q.start_with?('(award')
   md = Fbe::Award.new(q).bylaw.markdown
-  htmls << Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(md)
+  htmls << Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(escape_html: true)).render(md)
   par += 1
 end
 Fbe.fb.query('(eq what "bylaws")').delete!

--- a/judges/add-bylaws-html/escapes-embedded-html.yml
+++ b/judges/add-bylaws-html/escapes-embedded-html.yml
@@ -5,7 +5,7 @@ input:
   -
     what: pmp
     area: hr
-    abc: '(award (explain "Reward for <script>alert(1)</script>") (give 10 "test"))'
+    abc: '(award (explain "<script>alert(1)</script>") (give 10 "test"))'
 expected:
   - /fb[count(f)=2]
   - /fb/f[what='bylaws' and contains(html, '&lt;script&gt;')]

--- a/judges/add-bylaws-html/escapes-embedded-html.yml
+++ b/judges/add-bylaws-html/escapes-embedded-html.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  -
+    what: pmp
+    area: hr
+    abc: '(award (explain "Reward for <script>alert(1)</script>") (give 10 "test"))'
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='bylaws' and contains(html, '&lt;script&gt;')]
+  - /fb/f[what='bylaws' and not(contains(html, '<script>'))]


### PR DESCRIPTION
`judges/add-bylaws-html/add-bylaws-html.rb` rendered each PMP `(award ...)` bylaw's markdown with
`Redcarpet::Markdown.new(Redcarpet::Render::HTML)` — Redcarpet's default settings pass raw inline
HTML embedded in the markdown source straight through unescaped. Since `(explain "...")` and other
bylaw text ultimately becomes part of that markdown source, PMP text containing `<script>` (or
any other raw HTML) ends up executable in the resulting `bylaws/html` fact, which
`xsl/bylaws.xsl` then renders with `disable-output-escaping="yes"` — the XSS hardening item from
#581 (item 4). Today PMP is centrally administered, so this needs a compromised admin to trigger;
the fix is future-proofing for any role-separated PMP path.

Passed `escape_html: true` to `Redcarpet::Render::HTML`, which escapes embedded raw HTML in the
markdown source while leaving Redcarpet's own generated markup (from `**bold**`, `[links]()`,
etc.) untouched.

Added `judges/add-bylaws-html/escapes-embedded-html.yml`, a fixture whose PMP policy embeds a
`<script>` tag via `(explain ...)`, asserting the resulting `bylaws/html` fact contains the
escaped `&lt;script&gt;` form and not the raw tag.

## Verification

Installed this repo's `fbe`/`redcarpet`/`judges` gems locally and ran the actual test suite for
this judge:

```
$ judges --verbose test --no-log --judge=add-bylaws-html judges
👉 Testing add-bylaws-html.rb (#5) in judges/add-bylaws-html/...
add-bylaws-html/escapes-embedded-html    OK
add-bylaws-html/simple-policy            OK
add-bylaws-html/refreshes-stale          OK
add-bylaws-html/no-policy                OK
👍 All 1 judge(s) and 4 tests passed
```

All three pre-existing fixtures still pass (no regression to normal markdown formatting), and the
new fixture fails without the fix — reverted `escape_html: true` locally and confirmed
`escapes-embedded-html` is the only test that then fails, with the raw `<script>` tag present in
the rendered HTML.

Also ran `rubocop` on the changed Ruby file locally: no offenses.

Addresses the XSS hardening item (4) from #581 — items 1-3 (supply-chain) are already covered by
#690/#692; item 5 (href scheme allowlist in `awards.xsl`) and the cosmetic `$avg` typing note
remain open.
