### PR TITLE
#581: allowlist github.com href scheme in award links

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -174,4 +174,28 @@ class TestAwards < Minitest::Test
       assert_equal(v[1], xml.xpath('/span/text()').to_s, xml)
     end
   end
+
+  def test_programmer_rejects_non_github_href
+    now = Time.now.utc.iso8601
+    xml = xslt(
+      "<xsl:call-template name=\"programmer\">
+        <xsl:with-param name=\"id\" select=\"'x'\"/>
+        <xsl:with-param name=\"name\" select=\"'dude'\"/>
+      </xsl:call-template>",
+      "
+      <fb>
+        <f>
+          <is_human>1</is_human>
+          <when>#{now}</when>
+          <who_name>dude</who_name>
+          <award>25</award>
+          <why>evil</why>
+          <href>javascript:alert(1)</href>
+        </f>
+      </fb>
+      ",
+      'today' => now
+    )
+    assert_empty(xml.xpath("//a[starts-with(@href, 'javascript:')]"), xml)
+  end
 end

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -401,7 +401,7 @@
             <xsl:choose>
               <xsl:when test="z:in-week($fact/when, $week)">
                 <xsl:choose>
-                  <xsl:when test="$fact/href">
+                  <xsl:when test="$fact/href and starts-with($fact/href, 'https://github.com/')">
                     <a>
                       <xsl:attribute name="href">
                         <xsl:value-of select="$fact/href"/>


### PR DESCRIPTION
`xsl/awards.xsl`'s `programmer` named template copied a PMP award fact's `href` field verbatim
into an `<a href>` anchor, with no scheme or origin check:

```xsl
<xsl:when test="$fact/href">
  <a>
    <xsl:attribute name="href">
      <xsl:value-of select="$fact/href"/>
```

Every other award-related link in this same file uses `https://github.com/{$name}` — that's the
only legitimate origin for this href in the codebase today. If `href` ever becomes settable from
a less-privileged source (item 5 from #581), a `javascript:` URL executes on click. Today's
central PMP administration limits exploitability, but this is straightforward future-proofing.

Added a `starts-with($fact/href, 'https://github.com/')` guard to the existing condition. A fact
whose `href` isn't a `github.com` URL now falls through to the existing "hasn't been published
yet" span instead of rendering a clickable link.

## Verification

Downloaded this repo's pinned Saxon-HE 9.8.0-5 jar and ran the actual `programmer` named template
through it directly, with a fact whose `href` is `javascript:alert(1)`:

- **Without the fix**: output contains `<a href="javascript:alert(1)">`.
- **With the fix**: no such anchor appears; the award renders inside the existing
  "hasn't been published yet" fallback `<span>` instead.

Added `test_programmer_rejects_non_github_href` to `test/pages/test_awards.rb`, asserting
`//a[starts-with(@href, 'javascript:')]` is empty for such a fact. Could not run the full
`rake test` suite in this sandbox (`Minitest.load` is private on the locally available Minitest
version, unrelated to this change — `test/test__helper.rb` fails to load before reaching any
test file), so I validated the underlying XSLT transformation directly against Saxon instead
(shown above) and confirmed `rubocop` reports no offenses on both changed files.

Addresses the XSS hardening item (5) from #581.
