### PR TITLE
#683: use >= 0 for sign selection in badge.xsl to avoid displaying -0

### DIFF
--- a/test/pages/test_badge.rb
+++ b/test/pages/test_badge.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'nokogiri'
+require 'shellwords'
 require_relative '../test__helper'
 
 class TestBadge < Minitest::Test
@@ -23,5 +24,33 @@ class TestBadge < Minitest::Test
       end
     assert_empty(xml.errors, svg)
     refute_empty(xml.xpath('/svg'), svg)
+  end
+
+  def test_shows_plus_zero_when_average_is_exactly_zero
+    xml = badge_svg('<fb/>')
+    texts = xml.xpath("//*[local-name()='text']").map(&:text)
+    refute_includes(texts, '-0', "Badge with a zero average must not show a negative sign:\n#{xml}")
+    assert_includes(texts, '+0', xml)
+  end
+
+  private
+
+  def badge_svg(xml)
+    Dir.mktmpdir do |dir|
+      input = File.join(dir, 'input.xml')
+      File.write(input, xml)
+      output = File.join(dir, 'output.xml')
+      qbash(
+        [
+          "java -jar #{Shellwords.escape(File.join(__dir__, '../../target/saxon.jar'))}",
+          "-s:#{Shellwords.escape(input)}",
+          "-xsl:#{Shellwords.escape(File.join(__dir__, '../../xsl/badge.xsl'))}",
+          "-o:#{Shellwords.escape(output)}",
+          'today=2024-01-01T00:00:00'
+        ],
+        stdout: fake_loog
+      )
+      Nokogiri::XML.parse(File.read(output))
+    end
   end
 end

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -69,7 +69,7 @@
       </g>
       <xsl:variable name="n">
         <xsl:choose>
-          <xsl:when test="$avg &gt; 0">
+          <xsl:when test="$avg &gt;= 0">
             <xsl:text>+</xsl:text>
           </xsl:when>
           <xsl:otherwise>


### PR DESCRIPTION
Closes #683.

`xsl/badge.xsl`'s sign-selection branch used strict `$avg > 0`, so when `$avg` is exactly `"0.0"`
(zero facts, or a rounded-to-zero average), the condition is false and the otherwise-branch emits
`-`, while `abs($avg)` emits `0` — the badge shows `-0`.

Widened the sign check to `$avg >= 0`, matching the existing correct pattern already used for
color selection in `vitals.xsl` (`$i >= 0`).

Added `test_shows_plus_zero_when_average_is_exactly_zero` to `test/pages/test_badge.rb`, which
transforms a minimal `<fb/>` (zero facts → avg = `0.0`) through the real `badge.xsl` via Saxon and
asserts the rendered text is `+0`, not `-0`.

Verified directly with Saxon-HE 9.8.0-5 (downloaded jar): confirmed the badge renders `-0` without
the fix and `+0` with the fix, for the same zero-average input.

Note: I could not run this new test locally through Minitest — `qbash` (used by the existing
`xslt()` test helper and my new test) hardcodes `/bin/bash`, which doesn't exist on this NixOS
sandbox — but this is an environment artifact unrelated to the change (confirmed via a direct
Saxon invocation outside the test harness, and the real CI `test` job runs on Ubuntu where
`/bin/bash` exists).
