### PR TITLE
#687: filter facts by (exists when) before sort_by in normalize-metrics

### DIFF
--- a/judges/normalize-metrics/normalize-metrics.rb
+++ b/judges/normalize-metrics/normalize-metrics.rb
@@ -13,7 +13,7 @@ def fits?(name)
 end
 
 %w[quantity-of-deliverables quality-of-service].each do |qo|
-  facts = Fbe.fb.query("(eq what '#{qo}')").each.to_a
+  facts = Fbe.fb.query("(and (eq what '#{qo}') (exists when))").each.to_a
   facts.sort_by!(&:when)
   next if facts.empty?
   start = {}

--- a/judges/normalize-metrics/normalize-skips-fact-without-when.yml
+++ b/judges/normalize-metrics/normalize-skips-fact-without-when.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    what: quality-of-service
+    average_issue_lifetime: 433.54
+  -
+    when: 2024-05-18T22:22:22.8492Z
+    what: quality-of-service
+    average_issue_lifetime: 654.32
+expected:
+  - /fb[count(f)=2]


### PR DESCRIPTION
Closes #687.

## What happens

`judges/normalize-metrics/normalize-metrics.rb` queries facts for `quantity-of-deliverables` and
`quality-of-service` and immediately sorts the result by `when`:

```ruby
facts = Fbe.fb.query("(eq what '#{qo}')").each.to_a
facts.sort_by!(&:when)
```

Neither the factbase query nor the Ruby code filters out facts that lack a `when` property. If
any matching fact has no `when`, `f.when` returns `nil`, and `Array#sort_by!` internally calls
`<=>` between elements — `nil <=> "2024-05-18T22:22:22Z"` returns `nil` (not `-1`/`0`/`1`), and
Ruby's sort raises `ArgumentError: comparison of NilClass with String failed` (or an equivalent
`nil` comparison error) as soon as such a fact is present in a batch alongside any fact that does
have a `when`.

Every other judge in this codebase that sorts by `when` explicitly filters the query first:

```ruby
# judges/latest-assessment/latest-assessment.rb:8
"(and (eq what \"assessment\") (exists text) (exists when))"

# judges/index-eva/index-eva.rb:12
"(exists when)"
```

`normalize-metrics.rb` is the odd one out, so it crashes on a batch of otherwise-valid facts
where even one is missing `when` — data that every sibling judge already defends against.

## What should happen

The query should filter with `(exists when)` before the results ever reach `sort_by!`, exactly
like `latest-assessment` and `index-eva` already do, so a fact lacking `when` is simply skipped for
this judge's purposes instead of crashing the whole batch.

## The fix

```diff
- facts = Fbe.fb.query("(eq what '#{qo}')").each.to_a
+ facts = Fbe.fb.query("(and (eq what '#{qo}') (exists when))").each.to_a
```

## Test

Added `normalize-skips-fact-without-when.yml`: two `quality-of-service` facts, one with no `when`
property and one with a valid `when`. Without the fix, running this fixture through the real
`judges test` CLI reproduces the exact crash:

```
normalize-metrics/normal...skips-fact-without-when          	    0.004	ERROR
E: StandardError: 1 tests failed
```

With the fix applied, all 6 fixtures for this judge (the 5 pre-existing ones plus the new one)
pass:

```
👉 Testing normalize-metrics.rb (#4) in judges/normalize-metrics/...
  normalize-metrics/normalize-all                             	    0.217	OK
  normalize-metrics/normalize-one                             	    0.059	OK
  normalize-metrics/normalize_composite                       	    0.029	OK
  normalize-metrics/normalize-zero-start                      	    0.024	OK
  normalize-metrics/normal...skips-fact-without-when          	    0.016	OK
  normalize-metrics/normalize-none                            	    0.010	OK
👍 All 1 judge(s) and 6 tests passed in 363ms
```

`rubocop judges/normalize-metrics/normalize-metrics.rb` — no offenses.
