### PR TITLE
csscheck.yml: verify SHA-256 checksum of css-validator.jar before execution

### DIFF
--- a/.github/workflows/csscheck.yml
+++ b/.github/workflows/csscheck.yml
@@ -32,4 +32,5 @@ jobs:
         run: |
           wget -O css-validator.jar \
             https://github.com/w3c/css-validator/releases/download/cssval-20250226/css-validator.jar
+          sha256sum -c <<< '5f764d63be946cce3940deb154759bdc4413b898f766ae48f5f0e5c2212c8afd  css-validator.jar'
           java -jar css-validator.jar file:target/css/main.css


### PR DESCRIPTION
Fixes #675

Adds SHA-256 checksum verification of `css-validator.jar` before running it. The checksum (`5f764d63be946cce3940deb154759bdc4413b898f766ae48f5f0e5c2212c8afd`) was computed from the official release `cssval-20250226`.

If the JAR is compromised or corrupted, `sha256sum -c` will exit non-zero and the build will fail before executing arbitrary code.

When upgrading the css-validator version, the checksum must be updated accordingly.