### PR TITLE
csscheck.yml: add branch filter to trigger only on master

### DIFF
--- a/.github/workflows/csscheck.yml
+++ b/.github/workflows/csscheck.yml
@@ -5,7 +5,11 @@
 name: css validation
 'on':
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
Fixes #676

Adds `branches: [master]` to both `push` and `pull_request` triggers in `csscheck.yml`, matching the convention used by all other workflows in the repository (e.g. `shellcheck.yml`).