### PR TITLE
bashate.yml: pin bashate version to 2.1.1

### DIFF
--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
-      - run: pip install bashate
+      - run: pip install bashate==2.1.1
       - run: |
           readarray -t files < <(find . -name '*.sh')
           bashate -i E006,E003 "${files[@]}"


### PR DESCRIPTION
Fixes #677

Pins `bashate` to version `2.1.1` (the latest release) instead of installing the latest version at runtime (`pip install bashate` without constraints). This prevents supply chain attacks via malicious new releases on PyPI.