### PR TITLE
stylelint.yml: pin stylelint to 17.14.0 and stylelint-config-standard to 40.0.0

### DIFF
--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - run: npm install --global stylelint stylelint-config-standard
+      - run: npm install --global stylelint@17.14.0 stylelint-config-standard@40.0.0
       - run: stylelint sass/*.scss


### PR DESCRIPTION
Fixes #678

Pins `stylelint` to `17.14.0` and `stylelint-config-standard` to `40.0.0` (latest versions on npm) instead of installing without version constraints. Prevents supply chain attacks via malicious new releases.

Both packages maintain attestations and SLSA provenance on npm.