### PR TITLE
Add explicit permissions blocks to all 18 CI workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,8 @@ name: actionlint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -10,6 +10,8 @@ name: bashate
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   bashate:
     timeout-minutes: 15

--- a/.github/workflows/checkmake.yml
+++ b/.github/workflows/checkmake.yml
@@ -9,6 +9,8 @@ name: checkmake
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   checkmake:
     timeout-minutes: 15

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -10,6 +10,8 @@ name: copyrights
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   copyrights:
     timeout-minutes: 15

--- a/.github/workflows/csscheck.yml
+++ b/.github/workflows/csscheck.yml
@@ -6,7 +6,8 @@ name: css validation
 'on':
   push:
   pull_request:
-
+permissions:
+  contents: read
 jobs:
   validate-css:
     timeout-minutes: 15

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,6 +10,8 @@ name: hadolint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   hadolint:
     timeout-minutes: 15

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -10,6 +10,8 @@ name: make
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   make:
     timeout-minutes: 15

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,6 +10,8 @@ name: markdown-lint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   markdown-lint:
     timeout-minutes: 15

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -10,6 +10,8 @@ name: pdd
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   pdd:
     timeout-minutes: 15

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,8 @@ name: reuse
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   reuse:
     timeout-minutes: 15

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,8 @@ name: shellcheck
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   shellcheck:
     timeout-minutes: 15

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -10,6 +10,8 @@ name: stylelint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   stylelint:
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ name: test
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 15

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -8,6 +8,8 @@ name: titles
     - cron: '0 * * * *'
   issues:
     types: [opened]
+permissions:
+  issues: write
 jobs:
   titles:
     timeout-minutes: 15

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -10,6 +10,8 @@ name: typos
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   typos:
     timeout-minutes: 15

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -9,6 +9,9 @@ name: up
       - master
     tags:
       - '*'
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   up:
     timeout-minutes: 15

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -10,6 +10,8 @@ name: xcop
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   xcop:
     timeout-minutes: 15

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,6 +10,8 @@ name: yamllint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   yamllint:
     timeout-minutes: 15


### PR DESCRIPTION
Fixes #679

Adds explicit `permissions:` blocks to all 18 workflow files following the principle of least privilege:

- **16 read-only workflows** (`actionlint`, `bashate`, `checkmake`, `copyrights`, `csscheck`, `hadolint`, `make`, `markdown-lint`, `pdd`, `reuse`, `shellcheck`, `stylelint`, `test`, `typos`, `xcop`, `yamllint`) → `permissions: contents: read`
- **`up.yml`** (creates PRs via `peter-evans/create-pull-request`) → `permissions: contents: write, pull-requests: write`
- **`titles.yml`** (updates issue titles via third-party action `horw/issue-title-ai`) → `permissions: issues: write`

Previously all workflows inherited the full default `GITHUB_TOKEN` scope, violating least privilege and potentially breaking under restrictive repository defaults (particularly `up.yml`).