### PR TITLE
titles.yml: pin horw/issue-title-ai to full commit SHA

### DIFF
--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: horw/issue-title-ai@v0.1.8b
+      - uses: horw/issue-title-ai@2221301dec59c2a3cb3498227702cb6efb5c9d4d
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Fixes #680

Pins `horw/issue-title-ai` to the full commit SHA `2221301dec59c2a3cb3498227702cb6efb5c9d4d` (the commit behind tag `v0.1.8b`) instead of a mutable semver tag. Prevents silent version substitution if the tag is moved or the upstream repository is compromised, matching the same pattern used in `pdd.yml`.