### PR TITLE
copy-repo-names.rb: rescue all Octokit and Faraday errors instead of only NotFound/Unauthorized

### DIFF
--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -13,7 +13,7 @@ return if ids.empty?
 repos =
   ids.each_with_object({}) do |id, h|
     h[id] = Fbe.octo.repository(id)
-  rescue Octokit::NotFound, Octokit::Unauthorized
+  rescue Octokit::Error, Faraday::Error
     next
   end
 


### PR DESCRIPTION
Fixes #682

Changes the rescue clause from `Octokit::NotFound, Octokit::Unauthorized` to `Octokit::Error, Faraday::Error`. This catches:
- `Octokit::TooManyRequests` (429 — rate limiting, very common in CI/CD)
- `Octokit::InternalServerError` (500)
- `Octokit::BadGateway` (502)
- `Octokit::ServiceUnavailable` (503)
- `Faraday::ConnectionFailed` (network down)
- `Faraday::TimeoutError` (slow API)

Previously any of these would abort the entire judge mid-loop, leaving the database in a partially-updated state. Since repo details are non-critical enrichment, gracefully skipping a failed request is safe.