### PR TITLE
clipboard.js: only show success checkmark after copy Promise resolves

### DIFF
--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -9,7 +9,11 @@ $(() => {
       text = $this.attr('data-text');
     if (navigator.clipboard) {
       if (window.isSecureContext) {
-        navigator.clipboard.writeText(text).catch(() => {
+        navigator.clipboard.writeText(text).then(() => {
+          const $check = $('<span class="darkgreen"> ✓</span>');
+          $this.after($check);
+          $check.delay(1000).fadeOut();
+        }).catch(() => {
           alert('Failed to copy to clipboard!');
         });
       } else {
@@ -20,9 +24,6 @@ $(() => {
       alert('The clipboard is inaccessible!');
       return false;
     }
-    const $check = $('<span class="darkgreen"> ✓</span>');
-    $this.after($check);
-    $check.delay(1000).fadeOut();
     return false;
   });
 });


### PR DESCRIPTION
Fixes #684

The success checkmark (` ✓`) was appended to the DOM synchronously after calling `navigator.clipboard.writeText()`, before the async Promise resolved. If the copy failed, the user would see both the error alert AND the green checkmark simultaneously.

Moved the checkmark creation into a `.then()` callback so it only appears when the copy actually succeeds. If the Promise rejects, only the `.catch()` alert is shown.