### PR TITLE
normalize-metrics.rb: add missing .to_f on line 36 to prevent nil crash

### DIFF
--- a/judges/normalize-metrics/normalize-metrics.rb
+++ b/judges/normalize-metrics/normalize-metrics.rb
@@ -33,7 +33,7 @@ end
     f.all_properties.each do |prop|
       next unless fits?(prop)
       next if start[prop].zero?
-      v = f[prop].first
+      v = f[prop].first.to_f
       s = start[prop]
       diff = (v - s).to_f / start[prop]
       n = "n_#{prop}"


### PR DESCRIPTION
Fixes #686

Line 36 was missing `.to_f` (inconsistent with line 28 which has it). If `f[prop].first` is `nil` (malformed fact), the subtraction `v - s` on line 38 would crash with `NoMethodError: undefined method - for nil:NilClass`. Adding `.to_f` converts `nil` to `0.0`, matching the defensive pattern on line 28.