### PR TITLE
entry.sh: set LATEST_VERSION to empty instead of 'unknown' on API failure

### DIFF
--- a/entries/renders-version-mismatch-banner.sh
+++ b/entries/renders-version-mismatch-banner.sh
@@ -19,6 +19,8 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_LOGO=' \
   'INPUT_ADLESS=true' \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
+  'PAGES_ACTION_VERSION=0.0.1' \
+  'LATEST_VERSION=0.0.2' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
 grep "rendered by the pages-action" output/test-vitals.html

--- a/entry.sh
+++ b/entry.sh
@@ -18,11 +18,11 @@ if [ -z "${LATEST_VERSION}" ]; then
         LATEST_VERSION=$(curl "${curl_args[@]}" https://api.github.com/repos/zerocracy/pages-action/releases/latest | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' || echo "")
         if [ -z "${LATEST_VERSION}" ]; then
             echo "Could not fetch latest version from GitHub API"
-            LATEST_VERSION="unknown"
+            LATEST_VERSION=""
         fi
     else
         echo "curl not available, skipping version check"
-        LATEST_VERSION="unknown"
+        LATEST_VERSION=""
     fi
 fi
 


### PR DESCRIPTION
Fixes #661

When `curl` fails to reach the GitHub API (network error, rate limit), `LATEST_VERSION` was set to the literal string `"unknown"`. This was passed to `vitals.xsl`, where the condition `$latest-version != ""` evaluated to true, rendering a false "outdated version" warning with a broken link to `.../releases/tag/unknown`.

Changed both failure paths to set `LATEST_VERSION=""` instead. The XSL condition naturally handles the empty string — the warning simply won't appear when the latest version cannot be determined.