### PR TITLE
entry.sh: strip trailing slash from url input to prevent double slashes

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -198,6 +198,7 @@ else
 fi
 
 url=${INPUT_URL}
+url="${url%/}"
 if [ -z "${url}" ]; then
     url=https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}
     echo "The URL of the pages to publish is this one (change it using the 'url' parameter): ${url}"


### PR DESCRIPTION
Fixes #662

Adds `url="${url%/}"` after reading `INPUT_URL` to strip any trailing slash. Previously, a `url` like `https://example.com/myrepo/` would produce double slashes in badge Markdown: `//simple-badge.svg`. Now trailing slashes are normalized before the value is passed to XSL.