### PR TITLE
entry.sh: compute CSS integrity hash via direct pipe to avoid trailing newline loss

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -216,15 +216,10 @@ fi
 css_links=""
 for css in "${css_urls[@]}"; do
     echo "Calculating hash for: ${css}"
-    content=$(curl -sSf --max-time 30 "$css") || {
+    hash=$(curl -sSf --max-time 30 "$css" | openssl dgst -sha384 -binary | openssl base64 -A) || {
         echo "ERROR: Failed to fetch CSS from: ${css}" >&2
         exit 1
     }
-    hash=$(printf "%s" "$content" | openssl dgst -sha384 -binary | openssl base64 -A)
-    if [ -z "$hash" ]; then
-        echo "ERROR: Failed to calculate hash for: ${css}" >&2
-        exit 1
-    fi
     echo "Hash: ${hash}"
     css_links="${css_links}${css}|${hash}"$'\n'
 done


### PR DESCRIPTION
Fixes #691

Previously, the CSS integrity hash was computed by capturing `curl` output in a variable (`content=$(curl ...)`, which strips trailing newlines via command substitution) and then piping `printf "%s" "$content"` to `openssl`. If a CSS file ends with a trailing newline (common for text files), the hash would be computed over fewer bytes than the browser actually receives, causing SRI mismatch.

Now `curl` is piped directly to `openssl`, matching the existing JS hash pattern on line 238 (previously line 243). No bytes are lost regardless of file content.