### PR TITLE
#734: divide the earned value as a fraction

### DIFF
--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -31,7 +31,16 @@ input:
     ac: 433
     ev: 437
     pv: 0
+  -
+    start: 2024-04-17T22:22:22.8492Z
+    when: 2024-05-17T22:22:22.8492Z
+    what: earned-value
+    ac: 444
+    ev: 555
+    pv: 666
 expected:
-  - /fb[count(f)=4]
+  - /fb[count(f)=5]
   - /fb/f[n_spi]
   - /fb/f[n_cpi]
+  - /fb/f[ac=444 and n_cpi > 1.2 and n_cpi < 1.3]
+  - /fb/f[ac=444 and n_spi > 0.8 and n_spi < 0.9]

--- a/judges/index-eva/index-eva.rb
+++ b/judges/index-eva/index-eva.rb
@@ -20,6 +20,6 @@ Fbe.fb.query(
     (absent n_spi))
   "
 ).each do |f|
-  f.n_cpi = f.ev / f.ac
-  f.n_spi = f.ev / f.pv
+  f.n_cpi = f.ev.to_f / f.ac
+  f.n_spi = f.ev.to_f / f.pv
 end


### PR DESCRIPTION
`f.ev / f.ac` and `f.ev / f.pv` are integer divisions when the three
properties are integers, which they are in production, so a CPI of 1.25 was
stored as 1 and an SPI of 0.83 as 0. The chart drawn from those values
disagreed with the paragraph above it, which computes the same two indexes in
XPath, where division is floating point.

The dividend is a float now, so the quotient keeps its fraction.

The pack gained a fifth input with integer `ac`, `ev` and `pv`, and two
asserts on the indexes it produces; both fail on master as it is.

Closes #734
