### PR TITLE
#737: skip a repository property that GitHub left empty

### DIFF
--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -31,7 +31,16 @@ input:
     ac: 433
     ev: 437
     pv: 0
+  -
+    start: 2024-04-17T22:22:22.8492Z
+    when: 2024-05-17T22:22:22.8492Z
+    what: earned-value
+    ac: 444
+    ev: 555
+    pv: 666
 expected:
-  - /fb[count(f)=4]
+  - /fb[count(f)=5]
   - /fb/f[n_spi]
   - /fb/f[n_cpi]
+  - /fb/f[ac=444 and n_cpi > 1.2 and n_cpi < 1.3]
+  - /fb/f[ac=444 and n_spi > 0.8 and n_spi < 0.9]

--- a/judges/index-eva/index-eva.rb
+++ b/judges/index-eva/index-eva.rb
@@ -20,6 +20,6 @@ Fbe.fb.query(
     (absent n_spi))
   "
 ).each do |f|
-  f.n_cpi = f.ev / f.ac
-  f.n_spi = f.ev / f.pv
+  f.n_cpi = f.ev.to_f / f.ac
+  f.n_spi = f.ev.to_f / f.pv
 end


### PR DESCRIPTION
GitHub answers `null` for `description` on a repository without one and for
`language` on a docs-only repository. `nil.to_s` is an empty string, which the
factbase refuses, so the judge aborted mid-loop and every `repo-details` fact
after that repository was lost. `entry.sh` runs with `--max-cycles 1`, so there
is no retry.

The properties are set only when GitHub gave a value; `repositories.xsl` already
renders an absent one fine.

The fake client cannot answer `nil`, so the test drives the judge with a client
that answers the way GitHub does.

Closes #737
