### PR TITLE
#743: use the supplied logo as the favicon

### DIFF
--- a/entries/renders-adless-vitals.sh
+++ b/entries/renders-adless-vitals.sh
@@ -16,12 +16,14 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_FACTBASE=test.fb' \
   'INPUT_OUTPUT=output' \
   'INPUT_VERBOSE=false' \
-  'INPUT_LOGO=' \
+  'INPUT_LOGO=https://example.com/mylogo.svg' \
   'INPUT_ADLESS=true' \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   'LATEST_VERSION=0.0.0' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
 grep "The output will have no mention of Zerocracy" 'log.txt'
+
+grep 'rel="icon"' -A 1 'output/test-vitals.html' | grep 'https://example.com/mylogo.svg'
 
 grep -v zerocracy 'output/test-vitals.html'

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -142,6 +142,10 @@ class TestVitals < Minitest::Test
     refute_match(/zerocracy/i, html[%r{<meta name="description".*?/>}m].to_s, html)
   end
 
+  def test_favicon_points_to_the_logo
+    assert_equal('x', Nokogiri::HTML(generate_vitals_html).xpath('//link[@rel="icon"]/@href').to_s)
+  end
+
   private
 
   def generate_vitals_html(adless: 'false')

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -188,7 +188,7 @@
           <xsl:value-of select="$name"/>
         </title>
         <xsl:if test="$logo != ''">
-          <link rel="icon" href="https://www.zerocracy.com/svg/logo.svg" type="image/svg"/>
+          <link rel="icon" href="{$logo}" type="image/svg"/>
         </xsl:if>
         <xsl:call-template name="css-links">
           <xsl:with-param name="links" select="$css-links"/>


### PR DESCRIPTION
The condition tested the `logo` parameter while the `href` ignored it and always
pointed at the Zerocracy icon, so an adless page still made a third-party request
for it and a project with its own logo got the wrong icon.

`entry.sh` already picks the Zerocracy logo as the default only when `adless` is
false, so using the parameter keeps that fallback.

Closes #743
