### PR TITLE
#744: assert that the adless page names nobody

### DIFF
--- a/entries/renders-adless-vitals.sh
+++ b/entries/renders-adless-vitals.sh
@@ -24,4 +24,4 @@ env "GITHUB_WORKSPACE=$(pwd)" \
 
 grep "The output will have no mention of Zerocracy" 'log.txt'
 
-grep -v zerocracy 'output/test-vitals.html'
+! grep -qi zerocracy 'output/test-vitals.html'

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -142,9 +142,13 @@ class TestVitals < Minitest::Test
     refute_match(/zerocracy/i, html[%r{<meta name="description".*?/>}m].to_s, html)
   end
 
+  def test_adless_page_does_not_name_zerocracy
+    refute_match(/zerocracy/i, generate_vitals_html(adless: 'true', logo: ''))
+  end
+
   private
 
-  def generate_vitals_html(adless: 'false')
+  def generate_vitals_html(adless: 'false', logo: 'x')
     saxon = File.join(__dir__, '../../target/saxon.jar')
     skip("Saxon not built at #{saxon}") unless File.exist?(saxon)
     Dir.mktmpdir do |dir|
@@ -183,20 +187,21 @@ class TestVitals < Minitest::Test
           "-s:#{Shellwords.escape(input)}",
           "-xsl:#{Shellwords.escape(File.join(__dir__, '../../xsl/vitals.xsl'))}",
           "-o:#{Shellwords.escape(output)}"
-        ] + %w[
-          today=2024-09-26T04:04:04Z
-          name=test
-          logo=x
-          palette=classic
-          url=https://example.com
-          version=0.0.1
-          latest-version=0.0.2
-          fbe=0.0.50
-          css-links=
-          js-links=
-          css=body{}
-          js=
-        ].push("adless=#{adless}").map { |p| Shellwords.escape(p) },
+        ] + [
+          'today=2024-09-26T04:04:04Z',
+          'name=test',
+          "logo=#{logo}",
+          'palette=classic',
+          'url=https://example.com',
+          'version=0.0.1',
+          'latest-version=0.0.2',
+          'fbe=0.0.50',
+          "adless=#{adless}",
+          'css-links=',
+          'js-links=',
+          'css=body{}',
+          'js='
+        ].map { |p| Shellwords.escape(p) },
         stdout: fake_loog
       )
       File.read(output)

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -96,6 +96,19 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
+  <xsl:template name="release">
+    <xsl:param name="v"/>
+    <xsl:choose>
+      <xsl:when test="$adless = 'false'">
+        <a href="https://github.com/zerocracy/pages-action/releases/tag/{$v}">
+          <xsl:value-of select="$v"/>
+        </a>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$v"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
   <xsl:template name="javascript">
     <xsl:param name="url"/>
     <xsl:param name="integrity"/>
@@ -263,13 +276,13 @@
               <p class="red">
                 <span>
                   <xsl:text>The page was rendered by the pages-action </xsl:text>
-                  <a href="https://github.com/zerocracy/pages-action/releases/tag/{$version}">
-                    <xsl:value-of select="$version"/>
-                  </a>
+                  <xsl:call-template name="release">
+                    <xsl:with-param name="v" select="$version"/>
+                  </xsl:call-template>
                   <xsl:text>, while the latest version is </xsl:text>
-                  <a href="https://github.com/zerocracy/pages-action/releases/tag/{$latest-version}">
-                    <xsl:value-of select="$latest-version"/>
-                  </a>
+                  <xsl:call-template name="release">
+                    <xsl:with-param name="v" select="$latest-version"/>
+                  </xsl:call-template>
                 </span>
               </p>
             </xsl:if>


### PR DESCRIPTION
`grep -v` inverts which lines are printed, not the exit status, so the check
exited 0 on any HTML page and proved nothing. It asserts absence now.

With a real assertion the page turns out not to be clean: the `description` and
`og:description` meta tags say "supervised by Zerocracy" whatever `adless` is.
That wording is now behind the same gate as every other mention, so the adless
page names nobody, and a test renders it and checks that.

The favicon branch needs a non-empty logo, which leaks the Zerocracy icon until
the fix in #743 lands, so that part of the coverage goes with it.

Closes #744
