### PR TITLE
#742: sort the leaderboard by the group total

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -224,4 +224,27 @@ class TestAwards < Minitest::Test
     )
     assert_empty(xml.xpath("//a[starts-with(@href, 'javascript:')]"), xml)
   end
+
+  def test_leaderboard_sorts_by_the_total
+    now = Time.now.utc
+    xml = xslt(
+      '<xsl:apply-templates select="/" mode="awards"/>',
+      "
+      <fb>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>1</award>
+          <when>#{(now - (60 * 60)).iso8601}</when></f>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>1</award>
+          <when>#{(now - (60 * 60)).iso8601}</when></f>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>1</award>
+          <when>#{(now - (60 * 60)).iso8601}</when></f>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>1</award>
+          <when>#{(now - (60 * 60)).iso8601}</when></f>
+        <f><is_human>1</is_human><who>2</who><who_name>bob</who_name><award>3</award>
+          <when>#{(now - (60 * 60)).iso8601}</when></f>
+      </fb>
+      ",
+      'today' => now.iso8601
+    )
+    assert_equal(%w[@alice @bob], xml.xpath('//td/span/a/text()').map(&:to_s), xml)
+  end
 end

--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -228,7 +228,7 @@ class TestAwards < Minitest::Test
   def test_leaderboard_sorts_by_the_total
     now = Time.now.utc
     xml = xslt(
-      '<xsl:apply-templates select="/" mode="awards"/>',
+      '<r><xsl:apply-templates select="/" mode="awards"/></r>',
       "
       <fb>
         <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>1</award>

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -240,15 +240,11 @@
       </thead>
       <tbody>
         <xsl:for-each-group select="$facts" group-by="who_name">
-          <xsl:sort select="sum(award)" data-type="number" order="descending"/>
-          <xsl:variable name="id" select="who/text()"/>
-          <xsl:variable name="name" select="who_name/text()"/>
-          <xsl:if test="count($facts[who_name = $name]) &gt; 0">
-            <xsl:call-template name="programmer">
-              <xsl:with-param name="id" select="$id"/>
-              <xsl:with-param name="name" select="$name"/>
-            </xsl:call-template>
-          </xsl:if>
+          <xsl:sort select="sum(current-group()/award)" data-type="number" order="descending"/>
+          <xsl:call-template name="programmer">
+            <xsl:with-param name="id" select="who/text()"/>
+            <xsl:with-param name="name" select="who_name/text()"/>
+          </xsl:call-template>
         </xsl:for-each-group>
       </tbody>
       <tfoot>


### PR DESCRIPTION
Inside `for-each-group` a sort key is evaluated with the context item set to the
first item of the group, so `sum(award)` summed one fact, that programmer's first
award. The static page came out in the wrong order; the browser only hides it
because tablesorter re-sorts after load.

The key is `sum(current-group()/award)` now. The `count(...) > 0` guard next to it
is true by construction of the group, so it is gone.

Closes #742
