### PR TITLE
#739: count only human awards on the badge and in the meta

### DIFF
--- a/entries/renders-vitals-description.sh
+++ b/entries/renders-vitals-description.sh
@@ -16,16 +16,19 @@ bundle exec judges eval test.fb "
   f.award = 10
   f.who = 12345
   f.who_name = 'user1'
+  f.is_human = 1
   f = \$fb.insert
   f.when = '2024-06-26T00:00:00Z'
   f.award = 20
   f.who = 12345
   f.who_name = 'user1'
+  f.is_human = 1
   f = \$fb.insert
   f.when = '2023-10-22T00:00:00Z'
   f.award = 100
   f.who = 67890
   f.who_name = 'user2'
+  f.is_human = 1
 " > /dev/null
 
 env "GITHUB_WORKSPACE=$(pwd)" \

--- a/test/pages/test_badge.rb
+++ b/test/pages/test_badge.rb
@@ -33,6 +33,18 @@ class TestBadge < Minitest::Test
     assert_includes(texts, '+0', xml)
   end
 
+  def test_ignores_bot_awards
+    xml = badge_svg(
+      '
+      <fb>
+        <f><when>2023-12-01T00:00:00Z</when><award>10</award><is_human>1</is_human></f>
+        <f><when>2023-12-01T00:00:00Z</when><award>1000</award><is_human>0</is_human></f>
+      </fb>
+      '
+    )
+    assert_includes(xml.xpath("//*[local-name()='text']").map(&:text), '+10', xml)
+  end
+
   private
 
   def badge_svg(xml)

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -9,7 +9,7 @@
   <xsl:param name="today" as="xs:string"/>
   <xsl:template match="/fb">
     <xsl:variable name="since" select="xs:dateTime($today) - xs:dayTimeDuration('P256D')" as="xs:dateTime"/>
-    <xsl:variable name="facts" select=".//f[z:when(when) &gt; $since and award]"/>
+    <xsl:variable name="facts" select=".//f[z:when(when) &gt; $since and award and is_human = 1]"/>
     <xsl:variable name="sum" select="sum($facts/award)" as="xs:double"/>
     <xsl:variable name="count" select="count($facts)" as="xs:integer"/>
     <xsl:variable name="avg">

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -146,7 +146,7 @@
         <meta charset="UTF-8"/>
         <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
         <xsl:variable name="description">
-          <xsl:variable name="facts" select="$fb/f[z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award]"/>
+          <xsl:variable name="facts" select="$fb/f[z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award and is_human = 1]"/>
           <xsl:variable name="count" select="count($facts)" as="xs:integer"/>
           <xsl:variable name="avg" as="xs:double" select="if ($count = 0) then xs:double('0') else sum($facts/award) div $count"/>
           <xsl:text>The "</xsl:text>


### PR DESCRIPTION
The awards table counts human awards only, while the badge and the `description`
and `og:description` meta tags counted bots too, so the three numbers on one page
disagreed and a bot could move the badge at will.

All three use the same population now.

Closes #739
