### PR TITLE
#740: write null for a data point that is absent

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -94,4 +94,32 @@ class TestQoSection < Minitest::Test
       end
     end
   end
+
+  def test_missing_data_point_is_null
+    xml = xslt(
+      "<r><xsl:call-template name='qo-section'>" \
+      "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
+      "<xsl:with-param name='title' select=\"'QoS'\"/>" \
+      '</xsl:call-template></r>',
+      '<fb>
+        <f>
+          <when>2024-06-23T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.2</n_composite>
+        </f>
+        <f>
+          <when>2024-06-30T22:22:22Z</when>
+          <what>quality-of-service</what>
+        </f>
+        <f>
+          <when>2024-07-03T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.5</n_composite>
+        </f>
+      </fb>',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    js = xml.xpath('//script[not(@src)]').map(&:content).join
+    assert_includes(js, 'data:[0.2,null,0.5]', js)
+  end
 end

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -114,7 +114,7 @@
               </xsl:if>
               <xsl:variable name="cell" select="*[name()=$n]/text()"/>
               <xsl:choose>
-                <xsl:when test="$cell = ''">
+                <xsl:when test="empty($cell) or $cell = ''">
                   <xsl:text>null</xsl:text>
                 </xsl:when>
                 <xsl:otherwise>


### PR DESCRIPTION
When the fact does not carry the property, `$cell` is the empty sequence, and
`() = ''` is false in XPath, so the `null` branch never ran and `value-of` wrote
nothing. The Chart.js array got a hole, and a hole in the last position shortens
the array, which shifts the whole series against its labels.

The judge that feeds this skips a metric whose baseline is zero, so the absent
property is expected input.

Closes #740
