### PR TITLE
#745: assert what the index judge computes

### DIFF
--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -35,7 +35,9 @@ expected:
   - /fb[count(f)=4]
   - /fb[count(f[n_cpi])=2]
   - /fb[count(f[n_spi])=2]
-  - /fb/f[ac='433' and ev='4342.42' and starts-with(n_cpi,'10.02') and starts-with(n_spi,'0.66')]
+  - >
+    /fb/f[ac='433' and ev='4342.42' and starts-with(n_cpi,'10.02')
+    and starts-with(n_spi,'0.66')]
   - /fb/f[ev='0.0' and n_cpi='0.0' and n_spi='0.0']
   - /fb/f[not(ac) and not(n_cpi) and not(n_spi)]
   - /fb/f[pv='0' and not(n_cpi) and not(n_spi)]

--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -33,5 +33,9 @@ input:
     pv: 0
 expected:
   - /fb[count(f)=4]
-  - /fb/f[n_spi]
-  - /fb/f[n_cpi]
+  - /fb[count(f[n_cpi])=2]
+  - /fb[count(f[n_spi])=2]
+  - /fb/f[ac='433' and ev='4342.42' and starts-with(n_cpi,'10.02') and starts-with(n_spi,'0.66')]
+  - /fb/f[ev='0.0' and n_cpi='0.0' and n_spi='0.0']
+  - /fb/f[not(ac) and not(n_cpi) and not(n_spi)]
+  - /fb/f[pv='0' and not(n_cpi) and not(n_spi)]


### PR DESCRIPTION
`/fb/f[n_spi]` and `/fb/f[n_cpi]` are existential over the whole factbase, so one
fact carrying the property anywhere satisfied them. The pack checked that the
judge wrote something, never what, and never that it left the other facts alone.

It now asserts how many facts got the indexes, the values for the two facts that
qualify, and that the fact without `ac` and the one with a zero `pv` stay
untouched. Swapping `ac` for `pv` in the judge makes it fail.

Closes #745
