### PR TITLE
#738: cover the same interval in the facts and the columns

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -224,4 +224,24 @@ class TestAwards < Minitest::Test
     )
     assert_empty(xml.xpath("//a[starts-with(@href, 'javascript:')]"), xml)
   end
+
+  def test_week_columns_add_up_to_the_run
+    xml = xslt(
+      '<xsl:apply-templates select="/" mode="awards"/>',
+      '
+      <fb>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>100</award>
+          <when>2024-06-08T10:00:00Z</when></f>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>7</award>
+          <when>2024-07-01T00:00:00Z</when></f>
+        <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>5</award>
+          <when>2024-07-03T10:00:00Z</when></f>
+      </fb>
+      ',
+      'today' => '2024-07-05T00:00:00Z'
+    )
+    values = xml.xpath('//tbody/tr[1]/td[@data-value]').map { |t| t['data-value'].to_i }
+    assert_equal(values.last, values[0..-2].sum, xml)
+    assert_equal(12, values.last, xml)
+  end
 end

--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -227,7 +227,7 @@ class TestAwards < Minitest::Test
 
   def test_week_columns_add_up_to_the_run
     xml = xslt(
-      '<xsl:apply-templates select="/" mode="awards"/>',
+      '<r><xsl:apply-templates select="/" mode="awards"/></r>',
       '
       <fb>
         <f><is_human>1</is_human><who>1</who><who_name>alice</who_name><award>100</award>

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -7,8 +7,8 @@
   <xsl:include href="script-with-cdata.xsl"/>
   <xsl:variable name="days" select="z:pmp('hr', 'days_of_running_balance', '28')"/>
   <xsl:variable name="weeks" select="xs:integer(ceiling(xs:float($days) div 7))"/>
-  <xsl:variable name="since" select="xs:dateTime($today) - xs:dayTimeDuration(concat('P', $days, 'D'))"/>
-  <xsl:variable name="facts" select="$fb/f[award and z:when(when) &gt; $since and is_human = 1]"/>
+  <xsl:variable name="since" select="xs:dateTime(z:monday(1))"/>
+  <xsl:variable name="facts" select="$fb/f[award and z:when(when) &gt;= $since and is_human = 1]"/>
   <xsl:function name="z:monday" as="xs:date">
     <!--
     Takes week number (e.g. 4) and returns ISO-8601 date of the
@@ -32,7 +32,7 @@
     <xsl:param name="week" as="xs:integer"/>
     <xsl:variable name="monday" select="xs:dateTime(z:monday($week))"/>
     <xsl:variable name="sunday" select="$monday + xs:dayTimeDuration('P7D')"/>
-    <xsl:value-of select="$when &gt; $monday and $when &lt; $sunday"/>
+    <xsl:value-of select="$when &gt;= $monday and $when &lt; $sunday"/>
   </xsl:function>
   <xsl:function name="z:payables">
     <!--


### PR DESCRIPTION
`$since` was a rolling window ending today while each column is anchored to a
Monday, so unless today is a Monday the first column started after `$since` and
an award in that gap was counted in `Run` and in no column. `z:in-week` was also
strict on both ends, so an award at exactly Monday 00:00:00 fell between two
weeks.

`$since` is now the Monday of the first column, and a week is half-open, so the
columns cover exactly what `Run` sums.

Closes #738
