### PR TITLE
#755: reformat every stylesheet the way xcop wants it

### DIFF
--- a/xsl/assessment.xsl
+++ b/xsl/assessment.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="xs">
   <xsl:template match="/" mode="assessment">

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:include href="script-with-cdata.xsl"/>

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/2000/svg" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="xs">
   <xsl:output method="xml" omit-xml-declaration="yes"/>
@@ -17,7 +17,7 @@
           <xsl:text>0.0</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="format-number($sum div $count, '0.0')" />
+          <xsl:value-of select="format-number($sum div $count, '0.0')"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>

--- a/xsl/bylaws.xsl
+++ b/xsl/bylaws.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <xsl:template match="/" mode="bylaws">

--- a/xsl/dot.xsl
+++ b/xsl/dot.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:variable name="dot_facts" select="/fb/f[what='dimensions-of-terrain' and xs:dateTime(when) &gt; $since]"/>
   <xsl:template match="/" mode="dot">
     <xsl:choose>

--- a/xsl/eva-summary.xsl
+++ b/xsl/eva-summary.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:template match="f[what='earned-value' and ac and ev and pv and xs:double(ac) != 0 and xs:double(pv) != 0]" priority="2">
     <xsl:text>AC: </xsl:text>
     <xsl:value-of select="format-number(ac, '0')"/>

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:include href="script-with-cdata.xsl"/>
   <xsl:function name="z:iso-week" as="xs:string">
     <xsl:param name="dt" as="xs:dateTime"/>
@@ -89,7 +89,7 @@
             <xsl:text>{label:'</xsl:text>
             <xsl:value-of select="z:snake-case-to-title(substring-after($n, 'n_'))"/>
             <xsl:text>',borderColor:</xsl:text>
-            <xsl:variable name='c' select="substring-before(substring-after(concat(',', $colors, ','), concat(',', $n, ':')), ',')"/>
+            <xsl:variable name="c" select="substring-before(substring-after(concat(',', $colors, ','), concat(',', $n, ':')), ',')"/>
             <xsl:choose>
               <xsl:when test="$c">
                 <xsl:text>'</xsl:text>

--- a/xsl/repositories.xsl
+++ b/xsl/repositories.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <xsl:template match="/" mode="repositories">

--- a/xsl/script-with-cdata.xsl
+++ b/xsl/script-with-cdata.xsl
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <!--
-    Wraps the given JavaScript content in a <script> block with CDATA markers
-    so that XML-special characters (&, <, >) do not break XML parsing.
+  Wraps the given JavaScript content in a <script> block with CDATA markers
+  so that XML-special characters (&, <, >) do not break XML parsing.
   -->
   <xsl:template name="script-with-cdata">
     <xsl:param name="content"/>
     <script>
-      <xsl:text disable-output-escaping="yes">//&lt;![CDATA[&#10;</xsl:text>
+      <xsl:text disable-output-escaping="yes">//&lt;![CDATA[
+</xsl:text>
       <xsl:value-of select="$content" disable-output-escaping="yes"/>
-      <xsl:text disable-output-escaping="yes">&#10;//]]&gt;</xsl:text>
+      <xsl:text disable-output-escaping="yes">
+//]]&gt;</xsl:text>
     </script>
   </xsl:template>
 </xsl:stylesheet>

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" exclude-result-prefixes="xs z">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:include href="script-with-cdata.xsl"/>
   <xsl:output method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="yes"/>
   <xsl:param name="today" as="xs:string"/>
@@ -134,10 +134,10 @@
     </xsl:for-each>
   </xsl:template>
   <xsl:template match="/">
-    <xsl:text disable-output-escaping='yes'>&lt;!DOCTYPE html&gt;</xsl:text>
+    <xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;</xsl:text>
     <html lang="en">
       <xsl:attribute name="class">
-          <xsl:value-of select="concat('palette-', $palette)"/>
+        <xsl:value-of select="concat('palette-', $palette)"/>
       </xsl:attribute>
       <head>
         <meta charset="UTF-8"/>
@@ -354,7 +354,7 @@
               <a href="{$name}.html">
                 <xsl:text>here</xsl:text>
               </a>
-              <xsl:if test="fb/@size > 1000000">
+              <xsl:if test="fb/@size &gt; 1000000">
                 <xsl:text> (they're big)</xsl:text>
               </xsl:if>
               <xsl:text>.</xsl:text>


### PR DESCRIPTION
Ran `xcop --fix` over `xsl/*.xsl` and committed the result.

The header comment body lines lose their leading space, `version="2.0"` moves after the namespace declarations in four files, two single-quoted attributes become double-quoted, one space before `/>` goes away, and `&#10;` in `script-with-cdata.xsl` becomes a literal newline. A character reference and the character it names are the same thing to a parser, and attribute order and quote style are not part of the infoset, so nothing the stylesheets do changes.

After this, `xcop --license ./LICENSE.txt xsl/*.xsl` exits 0.

Closes #755
