### PR TITLE
#771: index the facts that have the numbers, whatever else they have

### DIFF
--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -31,7 +31,14 @@ input:
     ac: 433
     ev: 437
     pv: 0
+  -
+    when: 2024-05-17T22:22:22.8492Z
+    what: earned-value
+    ac: 433
+    ev: 4342.42
+    pv: 6540.56
 expected:
-  - /fb[count(f)=4]
+  - /fb[count(f)=5]
+  - /fb[count(f[n_cpi and n_spi])=3]
   - /fb/f[n_spi]
   - /fb/f[n_cpi]

--- a/judges/index-eva/index-eva.rb
+++ b/judges/index-eva/index-eva.rb
@@ -10,7 +10,6 @@ Fbe.fb.query(
   (and
     (eq what 'earned-value')
     (exists when)
-    (exists start)
     (exists ac)
     (not (eq ac 0))
     (exists pv)


### PR DESCRIPTION
`(exists start)` was in the query, but `start` is never read: the body computes `ev / ac` and
`ev / pv`. A fact carrying all three numbers got no indexes, and no log line said why.

The pack gains a fifth input, identical to the first but without `start`, and an assertion that
three of the five facts come out indexed. Without the change it is two.

Closes #771
