### PR TITLE
#770: write each index when its own denominator is there

### DIFF
--- a/judges/index-eva/add-indexes.yml
+++ b/judges/index-eva/add-indexes.yml
@@ -31,7 +31,14 @@ input:
     ac: 433
     ev: 437
     pv: 0
+  -
+    start: 2024-04-17T22:22:22.8492Z
+    when: 2024-05-17T22:22:22.8492Z
+    what: earned-value
+    ac: 0
+    ev: 437
+    pv: 6540.56
 expected:
-  - /fb[count(f)=4]
-  - /fb/f[n_spi]
-  - /fb/f[n_cpi]
+  - /fb[count(f)=5]
+  - /fb[count(f[n_cpi])=3]
+  - /fb[count(f[n_spi])=4]

--- a/judges/index-eva/index-eva.rb
+++ b/judges/index-eva/index-eva.rb
@@ -5,21 +5,34 @@
 
 require 'fbe/fb'
 
+common =
+  "
+  (eq what 'earned-value')
+  (exists when)
+  (exists start)
+  (exists ev)
+  "
+
 Fbe.fb.query(
   "
   (and
-    (eq what 'earned-value')
-    (exists when)
-    (exists start)
+    #{common}
     (exists ac)
     (not (eq ac 0))
-    (exists pv)
-    (not (eq pv 0))
-    (exists ev)
-    (absent n_cpi)
-    (absent n_spi))
+    (absent n_cpi))
   "
 ).each do |f|
   f.n_cpi = f.ev / f.ac
+end
+
+Fbe.fb.query(
+  "
+  (and
+    #{common}
+    (exists pv)
+    (not (eq pv 0))
+    (absent n_spi))
+  "
+).each do |f|
   f.n_spi = f.ev / f.pv
 end


### PR DESCRIPTION
One query demanded both denominators, so a week with no planned value lost its cost index too,
and a week with no actual cost lost its schedule index. Neither index needs the other's
denominator: `n_cpi` is `ev / ac` and `n_spi` is `ev / pv`.

There are two queries now, sharing the part that is common to both, so a fact gets whichever
index it can support.

The pack gains a fifth input with `ac: 0` and counts the two indexes separately: three facts
can carry `n_cpi`, four can carry `n_spi`. Before the change both counts were two.

Closes #770
