### PR TITLE
#772: name only the facts that need a name

### DIFF
--- a/judges/copy-who-names/copy-who-names.rb
+++ b/judges/copy-who-names/copy-who-names.rb
@@ -13,7 +13,12 @@ names =
       (exists name))'
   ).each.to_a.to_h { |f| [f.who, f.name] }
 
-Fbe.fb.query('(and (exists who) (not (exists who_name)))').each do |f|
+Fbe.fb.query(
+  '(and
+    (not (eq what "who-has-name"))
+    (exists who)
+    (not (exists who_name)))'
+).each do |f|
   n = names[f.who]
   next if n.nil?
   f.who_name = n

--- a/judges/copy-who-names/name-exists.yml
+++ b/judges/copy-who-names/name-exists.yml
@@ -13,4 +13,5 @@ input:
     where: github
 expected:
   - /fb[count(f)=2]
-  - /fb/f[who_name='travolta']
+  - /fb/f[what='something' and who_name='travolta']
+  - /fb/f[what='who-has-name' and not(who_name)]


### PR DESCRIPTION
The query had no `what` restriction, and a `who-has-name` fact has a `who`, so the name
registry matched its own lookup table and got a copy of the name it already held. The
duplicate property then travelled into every YAML, XML and JSON dump the entry script writes.

The pack now checks both sides: the `something` fact gets the name, the `who-has-name` fact
does not.

Closes #772
