### PR TITLE
#766: print the average with the decimal it was formatted with

### DIFF
--- a/test/pages/test_badge.rb
+++ b/test/pages/test_badge.rb
@@ -30,7 +30,20 @@ class TestBadge < Minitest::Test
     xml = badge_svg('<fb/>')
     texts = xml.xpath("//*[local-name()='text']").map(&:text)
     refute_includes(texts, '-0', "Badge with a zero average must not show a negative sign:\n#{xml}")
-    assert_includes(texts, '+0', xml)
+    assert_includes(texts, '+0.0', xml)
+  end
+
+  def test_shows_one_decimal_for_a_whole_average
+    xml = badge_svg(
+      "
+      <fb>
+        <f><award>4</award><when>2023-12-01T00:00:00Z</when></f>
+        <f><award>4</award><when>2023-12-02T00:00:00Z</when></f>
+      </fb>
+      "
+    )
+    texts = xml.xpath("//*[local-name()='text']").map(&:text)
+    assert_includes(texts, '+4.0', xml)
   end
 
   private

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -78,10 +78,10 @@
         </xsl:choose>
         <xsl:choose>
           <xsl:when test="abs($avg) &gt; 999">
-            <xsl:text>999</xsl:text>
+            <xsl:text>999.0</xsl:text>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:value-of select="abs($avg)"/>
+            <xsl:value-of select="format-number(abs($avg), '0.0')"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:variable>


### PR DESCRIPTION
`$avg` is built with `format-number(..., '0.0')`, and then `abs($avg)` cast the string back to a
double, which undid the formatting. A whole average printed as `+4`, while a fractional one kept
its decimal and the `description` meta on the vitals page said `+4.0`.

Formatting the absolute value keeps the sign logic and the clamp untouched, and the clamp text
gains the same decimal so all three branches agree.

One existing assertion moves from `+0` to `+0.0`. #683 was about the badge showing `-0`, and the
badge still shows no minus for a zero average; the `+0` in that assertion was whatever the double
happened to print at the time, not the point being pinned.

Closes #766
