### PR TITLE
#765: let the summary carry its own paragraph

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -58,6 +58,25 @@ class TestQoSection < Minitest::Test
     assert_equal('2024-W52', xml.xpath('//r/text()').to_s.strip)
   end
 
+  def test_keeps_the_before_block_out_of_a_paragraph
+    xml = xslt(
+      "<r><xsl:call-template name='qo-section'>" \
+      "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
+      "<xsl:with-param name='title' select=\"'QoS'\"/>" \
+      "<xsl:with-param name='before'><p class='darkred'>Nope.</p></xsl:with-param>" \
+      '</xsl:call-template></r>',
+      '<fb>
+        <f>
+          <when>2024-07-03T22:22:22Z</when>
+          <what>quality-of-service</what>
+          <n_composite>0.5</n_composite>
+        </f>
+      </fb>',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    assert_empty(xml.xpath('//p//p'), xml)
+  end
+
   def test_inline_js_syntax_in_generated_html
     xml = xslt(
       "<r><xsl:call-template name='qo-section'>" \

--- a/xsl/eva-summary.xsl
+++ b/xsl/eva-summary.xsl
@@ -5,17 +5,19 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:template match="f[what='earned-value' and ac and ev and pv and xs:double(ac) != 0 and xs:double(pv) != 0]" priority="2">
-    <xsl:text>AC: </xsl:text>
-    <xsl:value-of select="format-number(ac, '0')"/>
-    <xsl:text>, EV: </xsl:text>
-    <xsl:value-of select="format-number(ev, '0')"/>
-    <xsl:text>, PV: </xsl:text>
-    <xsl:value-of select="format-number(pv, '0')"/>
-    <xsl:text>, CPI: </xsl:text>
-    <xsl:copy-of select="z:index(ev div ac)"/>
-    <xsl:text>, SPI: </xsl:text>
-    <xsl:copy-of select="z:index(ev div pv)"/>
-    <xsl:text>.</xsl:text>
+    <p>
+      <xsl:text>AC: </xsl:text>
+      <xsl:value-of select="format-number(ac, '0')"/>
+      <xsl:text>, EV: </xsl:text>
+      <xsl:value-of select="format-number(ev, '0')"/>
+      <xsl:text>, PV: </xsl:text>
+      <xsl:value-of select="format-number(pv, '0')"/>
+      <xsl:text>, CPI: </xsl:text>
+      <xsl:copy-of select="z:index(ev div ac)"/>
+      <xsl:text>, SPI: </xsl:text>
+      <xsl:copy-of select="z:index(ev div pv)"/>
+      <xsl:text>.</xsl:text>
+    </p>
   </xsl:template>
   <xsl:template match="f[what='earned-value']" priority="1">
     <p class="darkred">

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -47,9 +47,7 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:if test="$before != ''">
-          <p>
-            <xsl:copy-of select="$before"/>
-          </p>
+          <xsl:copy-of select="$before"/>
         </xsl:if>
         <div class="qo-section">
           <canvas id="{$what}">


### PR DESCRIPTION
`qo-section` wrapped `$before` in a `<p>`, and the only caller passes the EVA summary, whose
short branch is already a `<p class="darkred">`. The result was `<p><p class="darkred">...</p></p>`,
which no browser keeps: the outer paragraph closes at the inner one and the class lands on a node
that is no longer where the markup put it.

Both branches of the summary now produce the paragraph themselves, and `qo-section` copies the
block through untouched, so the two cannot disagree again.

Closes #765
