### PR TITLE
#764: read one policy fact, whatever the factbase holds

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -54,6 +54,27 @@ class TestVitals < Minitest::Test
     assert_equal('bar', xml.xpath('/r/text()').to_s, xml)
   end
 
+  def test_fn_pmp_reads_one_fact
+    xml = xslt(
+      '<r><xsl:value-of select="z:pmp(\'hr\', \'days_of_running_balance\', \'28\')"/></r>',
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>28</days_of_running_balance>
+        </f>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>56</days_of_running_balance>
+        </f>
+      </fb>
+      '
+    )
+    assert_equal('28', xml.xpath('/r/text()').to_s, xml)
+  end
+
   def test_fn_format_signed
     {
       3.3 => ['0.0', '+3.3'],

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -75,10 +75,10 @@
     <xsl:param name="area" as="xs:string"/>
     <xsl:param name="param" as="xs:string"/>
     <xsl:param name="default" as="xs:string"/>
-    <xsl:variable name="a" select="$fb/f[what='pmp' and area=$area]"/>
+    <xsl:variable name="a" select="$fb/f[what='pmp' and area=$area][1]"/>
     <xsl:choose>
       <xsl:when test="$a">
-        <xsl:variable name="v" select="$a/*[name()=$param]/text()"/>
+        <xsl:variable name="v" select="$a/*[name()=$param][1]/text()"/>
         <xsl:choose>
           <xsl:when test="$v">
             <xsl:value-of select="$v"/>


### PR DESCRIPTION
`z:pmp` selected every `pmp` fact of the area and every matching property inside them, so two
facts for one area ran their values together into one string: `28` and `56` came back as `2856`.
The only caller turns that into the number of week columns, so the awards table grew to 408
columns and the running balance window to 2856 days, with no error anywhere.

The function now reads the first fact and the first value, the way `Fbe.pmp` does on the Ruby
side.

Closes #764
