### PR TITLE
#763: show the latest fact of the week, not the last one written

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -86,6 +86,33 @@ class TestVitals < Minitest::Test
     assert_equal('bar', xml.xpath('/r/text()').to_s, xml)
   end
 
+  def test_dot_shows_the_latest_fact_of_the_week
+    xml = xslt(
+      "<r><xsl:apply-templates select='/' mode='dot'/></r>",
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>7</days_of_running_balance>
+        </f>
+        <f>
+          <what>dimensions-of-terrain</what>
+          <when>2024-07-04T00:00:00Z</when>
+          <total_repositories>99</total_repositories>
+        </f>
+        <f>
+          <what>dimensions-of-terrain</what>
+          <when>2024-07-02T00:00:00Z</when>
+          <total_repositories>3</total_repositories>
+        </f>
+      </fb>
+      ',
+      'today' => '2024-07-05T00:00:00Z'
+    )
+    assert_equal('99', xml.xpath('//td[@class="ff right"]/text()').to_s.strip, xml)
+  end
+
   def test_fn_format_signed
     {
       3.3 => ['0.0', '+3.3'],

--- a/xsl/dot.xsl
+++ b/xsl/dot.xsl
@@ -65,7 +65,12 @@
             </td>
             <xsl:for-each select="1 to $weeks">
               <xsl:variable name="week" select="xs:integer(.)"/>
-              <xsl:variable name="f" select="$dot_facts[z:in-week(z:when(when), $week)][last()]"/>
+              <xsl:variable name="sorted" as="element()*">
+                <xsl:perform-sort select="$dot_facts[z:in-week(z:when(when), $week)]">
+                  <xsl:sort select="z:when(when)" order="ascending"/>
+                </xsl:perform-sort>
+              </xsl:variable>
+              <xsl:variable name="f" select="$sorted[last()]"/>
               <td class="ff right">
                 <xsl:choose>
                   <xsl:when test="$f">


### PR DESCRIPTION
`[last()]` is a position in the sequence, and the sequence is in document order, so the cell
showed whichever fact of the week happened to be written last, not the one measured last. A
newer measurement was hidden behind an older one, and a dimension that only the newer fact
carried came out as a blank cell although the data was there.

`xsl:perform-sort` on `when` puts the week's facts in time order first, which is what
`qo-section.xsl` already does for its own weekly grouping.

Closes #763
