### PR TITLE
#762: give every award a row, named or not

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -9,6 +9,36 @@ require 'qbash'
 require_relative '../test__helper'
 
 class TestAwards < Minitest::Test
+  def test_gives_a_row_to_an_award_with_no_name
+    xml = xslt(
+      "<r><xsl:apply-templates select='/' mode='awards'/></r>",
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>7</days_of_running_balance>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <who>1</who>
+          <who_name>jeff</who_name>
+          <award>10</award>
+          <when>2024-07-02T00:00:00Z</when>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <who>2</who>
+          <award>25</award>
+          <when>2024-07-03T00:00:00Z</when>
+        </f>
+      </fb>
+      ',
+      'today' => '2024-07-05T00:00:00Z'
+    )
+    assert_equal(2, xml.xpath('//tbody/tr[not(@class)]').size, xml)
+  end
+
   def test_fn_payables
     xml = xslt(
       "<xsl:copy-of select=\"z:payables('dude')\"/>",

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -239,16 +239,13 @@
         </tr>
       </thead>
       <tbody>
-        <xsl:for-each-group select="$facts" group-by="who_name">
+        <xsl:for-each-group select="$facts" group-by="who">
           <xsl:sort select="sum(award)" data-type="number" order="descending"/>
           <xsl:variable name="id" select="who/text()"/>
-          <xsl:variable name="name" select="who_name/text()"/>
-          <xsl:if test="count($facts[who_name = $name]) &gt; 0">
-            <xsl:call-template name="programmer">
-              <xsl:with-param name="id" select="$id"/>
-              <xsl:with-param name="name" select="$name"/>
-            </xsl:call-template>
-          </xsl:if>
+          <xsl:call-template name="programmer">
+            <xsl:with-param name="id" select="$id"/>
+            <xsl:with-param name="name" select="(who_name/text(), who/text())[1]"/>
+          </xsl:call-template>
         </xsl:for-each-group>
       </tbody>
       <tfoot>
@@ -314,7 +311,7 @@
           </a>
         </span>
         <xsl:text> (</xsl:text>
-        <xsl:variable name="c" select="count($facts[who_name=$name]/award)"/>
+        <xsl:variable name="c" select="count($facts[who=$id]/award)"/>
         <a href="#" onclick="$('.p_{$name}').toggle(); return false;">
           <xsl:value-of select="$c"/>
           <xsl:text> award</xsl:text>
@@ -326,9 +323,9 @@
       </td>
       <xsl:for-each select="1 to $weeks">
         <xsl:variable name="week" select="."/>
-        <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who_name=$name and z:in-week(z:when(when), $week)]/award)))"/>
+        <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who=$id and z:in-week(z:when(when), $week)]/award)))"/>
       </xsl:for-each>
-      <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who_name=$name]/award)))"/>
+      <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who=$id]/award)))"/>
       <xsl:if test="$fb/f[what='reconciliation']">
         <xsl:copy-of select="z:payables($name)"/>
       </xsl:if>
@@ -385,7 +382,7 @@
         </td>
       </tr>
     </xsl:if>
-    <xsl:for-each select="$facts[who_name=$name]">
+    <xsl:for-each select="$facts[who=$id]">
       <xsl:sort select="when" data-type="text"/>
       <xsl:variable name="fact" select="."/>
       <tr class="sub tablesorter-childRow p-table p_{$name}" style="display: none;">


### PR DESCRIPTION
The body grouped by `who_name`, which the `copy-who-names` judge only fills in when a matching
`who-has-name` fact exists. An item whose grouping key is an empty sequence joins no group at
all, so an award for a user whose name is not resolved yet vanished from the table, while the
footer, which does not group, still counted it. The columns did not add up and nothing said a
row was missing.

Grouping is by `who` now, which every award carries, and the row selects its own facts by that
id too, so a name is only ever used for display. When the name is missing the id stands in, so
the row is still there and still adds up. This also keeps two users with the same display name
in two rows instead of one.

The `xsl:if` around the call went away with it: `count($facts[who_name = $name]) > 0` was true
for every group `for-each-group` had just produced.

Closes #762
