### PR TITLE
#767: keep Zerocracy out of the description of an adless page

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -105,9 +105,14 @@ class TestVitals < Minitest::Test
     assert_equal('sha384-abc123', link['integrity'])
   end
 
+  def test_adless_page_does_not_name_zerocracy_in_its_description
+    html = generate_vitals_html(adless: 'true')
+    refute_match(/zerocracy/i, html[%r{<meta name="description".*?/>}m].to_s, html)
+  end
+
   private
 
-  def generate_vitals_html
+  def generate_vitals_html(adless: 'false')
     saxon = File.join(__dir__, '../../target/saxon.jar')
     skip("Saxon not built at #{saxon}") unless File.exist?(saxon)
     Dir.mktmpdir do |dir|
@@ -155,12 +160,11 @@ class TestVitals < Minitest::Test
           version=0.0.1
           latest-version=0.0.2
           fbe=0.0.50
-          adless=false
           css-links=
           js-links=
           css=body{}
           js=
-        ].map { |p| Shellwords.escape(p) },
+        ].push("adless=#{adless}").map { |p| Shellwords.escape(p) },
         stdout: fake_loog
       )
       File.read(output)

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -148,7 +148,11 @@
           <xsl:variable name="avg" as="xs:double" select="if ($count = 0) then xs:double('0') else sum($facts/award) div $count"/>
           <xsl:text>The "</xsl:text>
           <xsl:value-of select="$name"/>
-          <xsl:text>" product is supervised by Zerocracy: </xsl:text>
+          <xsl:text>" product</xsl:text>
+          <xsl:if test="$adless = 'false'">
+            <xsl:text> is supervised by Zerocracy</xsl:text>
+          </xsl:if>
+          <xsl:text>: </xsl:text>
           <xsl:value-of select="z:format-signed($avg, '0.0')"/>
           <xsl:text> average points per task, </xsl:text>
           <xsl:value-of select="format-number(sum($facts/award), '0')"/>


### PR DESCRIPTION
`adless` is documented as hiding all Zerocracy links, banners and logos, and the entry script
logs that the output will have no mention of Zerocracy, but the `description` and
`og:description` sentences said "supervised by Zerocracy" whatever the flag was. Those two are
the SEO text and the social-media preview card, so a white-labelled page carried the branding
into search results and into every link someone shared.

The name of the sponsor is now the only part that the flag removes; the numbers after it stay.

Closes #767
