### PR TITLE
#768: leave the raw samples alone

### DIFF
--- a/judges/normalize-metrics/normalize-metrics.rb
+++ b/judges/normalize-metrics/normalize-metrics.rb
@@ -9,6 +9,7 @@ def fits?(name)
   return true if name == 'composite'
   return false unless name.match?(/^[a-z]+_[a-z]+.*$/)
   return false if name.start_with?('n_')
+  return false if name.start_with?('some_')
   true
 end
 

--- a/judges/normalize-metrics/skips-raw-samples.yml
+++ b/judges/normalize-metrics/skips-raw-samples.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  -
+    what: quality-of-service
+    when: 2024-01-01T00:00:00Z
+    some_issue_lifetime: 10
+    average_issue_lifetime: 100
+  -
+    what: quality-of-service
+    when: 2024-01-08T00:00:00Z
+    some_issue_lifetime: 30
+    average_issue_lifetime: 200
+expected:
+  - /fb[count(f)=2]
+  - /fb[count(f[n_some_issue_lifetime])=0]
+  - /fb/f[n_average_issue_lifetime='1.0']


### PR DESCRIPTION
Quality-of-service facts carry raw sample arrays named `some_*`, written one value at a time by
the collector. `fits?` accepted them, and the judge reads `f[prop].first`, so it normalized one
arbitrary sample against one arbitrary sample of the baseline week. In the added pack that is
`30 / 10`, a reported +200% for a metric whose real average fell from 100 to 200 the other way.

`qo-section.xsl` charts every `n_*` property it finds, so each of those became an extra
meaningless series next to the real `n_average_*` ones.

The name is rejected the way `n_` already is. The new pack checks that no `n_some_*` is written
and that the average next to it still is.

Closes #768
