### PR TITLE
#769: recompute the normalized value on every run

### DIFF
--- a/judges/normalize-metrics/normalize-metrics.rb
+++ b/judges/normalize-metrics/normalize-metrics.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/fb'
+require 'fbe/overwrite'
 
 def fits?(name)
   return true if name == 'composite'
@@ -30,15 +31,15 @@ end
     end
   end
   facts.each do |f|
+    fresh = {}
     f.all_properties.each do |prop|
       next unless fits?(prop)
       next if start[prop].zero?
       v = f[prop].first.to_f
       s = start[prop]
-      diff = (v - s).to_f / start[prop]
-      n = "n_#{prop}"
-      next if f[n]
-      f.send(:"#{n}=", diff)
+      fresh["n_#{prop}"] = (v - s).to_f / s
     end
+    next if fresh.empty?
+    Fbe.overwrite(f, fresh)
   end
 end

--- a/test/judges/test_normalize_metrics.rb
+++ b/test/judges/test_normalize_metrics.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'time'
+require_relative '../test__helper'
+
+class TestNormalizeMetrics < Minitest::Test
+  def test_recomputes_when_an_earlier_sample_arrives
+    fb = Factbase.new
+    later = fb.insert
+    later._id = 1
+    later.what = 'quality-of-service'
+    later.when = Time.parse('2024-01-08T00:00:00Z')
+    later.average_issue_lifetime = 200
+    load_it('normalize-metrics', fb)
+    earlier = fb.insert
+    earlier._id = 2
+    earlier.what = 'quality-of-service'
+    earlier.when = Time.parse('2024-01-01T00:00:00Z')
+    earlier.average_issue_lifetime = 100
+    load_it('normalize-metrics', fb)
+    f = fb.query('(eq average_issue_lifetime 200)').each.to_a.first
+    assert_in_delta(1.0, f['n_average_issue_lifetime'].first, 0.0001, fb.to_json)
+  end
+end


### PR DESCRIPTION
`next if f[n]` meant a normalized value was written once and never revised, but its baseline is
"the earliest fact that carries the property right now", and that set grows between runs. The
collector fills a limited number of metrics per fact per run and retries the ones that came back
empty, so a metric can land on a later-dated fact before an earlier-dated one. When the earlier
value finally arrived, everything already written stayed frozen against the old baseline, and the
chart showed a flat line at zero for a metric that had doubled.

The values are collected per fact and handed to `Fbe.overwrite` in one go, so the fact is
recreated at most once and only when something actually changed.

The new test runs the judge twice, adding the earlier sample in between, and checks the later
week reads `1.0` rather than the `0.0` it was given on the first pass.

Closes #769
