### PR TITLE
#773: read the adless flag the same way everywhere

### DIFF
--- a/entries/uses-default-logo-without-adless.sh
+++ b/entries/uses-default-logo-without-adless.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+BUNDLE_GEMFILE="${SELF}/Gemfile"
+export BUNDLE_GEMFILE
+bundle exec judges eval test.fb "\$fb.insert" > /dev/null
+
+env "GITHUB_WORKSPACE=$(pwd)" \
+  'GITHUB_REPOSITORY=foo/bar' \
+  'GITHUB_REPOSITORY_OWNER=foo' \
+  'INPUT_FACTBASE=test.fb' \
+  'INPUT_OUTPUT=output' \
+  'INPUT_VERBOSE=false' \
+  'INPUT_LOGO=' \
+  'INPUT_GITHUB-TOKEN=THETOKEN' \
+  'LATEST_VERSION=0.0.0' \
+  "${SELF}/entry.sh" 2>&1 | tee log.txt
+
+grep 'The output HTML will have links to Zerocracy' 'log.txt'
+
+grep 'The default Zerocracy logo will be used' 'log.txt'

--- a/entry.sh
+++ b/entry.sh
@@ -178,7 +178,7 @@ else
 fi
 
 logo=${INPUT_LOGO}
-if [ -z "${logo}" ] && [ "${INPUT_ADLESS}" == 'false' ]; then
+if [ -z "${logo}" ] && [ "${INPUT_ADLESS}" != 'true' ]; then
     logo=https://www.zerocracy.com/svg/logo.svg
     echo "The default Zerocracy logo will be used: ${logo}"
 fi


### PR DESCRIPTION
Line 181 compared the flag to `false` while lines 194 and 214 compare it to `true`, so an unset
`INPUT_ADLESS` produced a page with no logo but with the Zerocracy palette and links, and a log
line saying the output would have those links. The action's own default fills the value in under
GitHub Actions, so this only showed up in direct and Docker runs, which is what the make targets
and most of the entry scripts use.

The new entry script runs the script with the flag unset and checks both halves agree.

Closes #773
