### PR TITLE
#761: let a week keep the award that starts it

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -189,6 +189,23 @@ class TestAwards < Minitest::Test
     assert_includes(th['title'], 'Week #1 in 2026', xml)
   end
 
+  def test_fn_in_week_takes_midnight_of_monday
+    xml = xslt(
+      '<r><xsl:value-of select="z:in-week(xs:dateTime(\'2024-09-23T00:00:00Z\'), 2)"/></r>',
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>14</days_of_running_balance>
+        </f>
+      </fb>
+      ',
+      'today' => '2024-09-26T04:04:04Z'
+    )
+    assert_equal('true', xml.xpath('/r/text()').to_s, xml)
+  end
+
   def test_fn_award
     {
       42 => ['darkgreen', '+42'],

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -32,7 +32,7 @@
     <xsl:param name="week" as="xs:integer"/>
     <xsl:variable name="monday" select="xs:dateTime(z:monday($week))"/>
     <xsl:variable name="sunday" select="$monday + xs:dayTimeDuration('P7D')"/>
-    <xsl:value-of select="$when &gt; $monday and $when &lt; $sunday"/>
+    <xsl:value-of select="$when &gt;= $monday and $when &lt; $sunday"/>
   </xsl:function>
   <xsl:function name="z:payables">
     <!--


### PR DESCRIPTION
The lower bound of a week was strict, so an award timestamped at exactly midnight on the Monday
belonged to no column: its own week starts one instant later, and the week before ends at the
same instant, which the upper bound excludes too. The row total is summed over the whole window
and did include the award, so the weekly cells of that row stopped adding up to it. `dot.xsl`
splits its rows with the same function.

The bound is inclusive now, so every fact inside the window lands in exactly one column.

Closes #761
