### PR TITLE
#758: colour an index against one, not against zero

### DIFF
--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -28,9 +28,10 @@ class TestVitals < Minitest::Test
 
   def test_fn_index
     {
-      3.3 => ['darkgreen', '+3.30'],
-      0 => ['darkgreen', '+0.00'],
-      -1 => ['darkred', '-1.00']
+      3.3 => ['darkgreen', '3.30'],
+      1 => ['darkgreen', '1.00'],
+      0.2 => ['darkred', '0.20'],
+      0 => ['darkred', '0.00']
     }.each do |k, v|
       xml = xslt("<xsl:copy-of select='z:index(#{k})'/>", '<fb/>')
       assert_equal(v[0], xml.xpath('/span/@class').to_s, xml)

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -47,14 +47,16 @@
   </xsl:function>
   <xsl:function name="z:index">
     <!--
-    Converts a number to a "span" with a properly formatted index value.
-    The span will have a "class" with the HTML color, according to the value.
+    Converts a performance index to a "span" with a properly formatted value.
+    An index is a ratio of two amounts, so its neutral point is one, not zero,
+    and it carries no sign. The span will have a "class" with the HTML color,
+    according to the value.
     -->
     <xsl:param name="i" as="xs:double"/>
     <span>
       <xsl:attribute name="class">
         <xsl:choose>
-          <xsl:when test="$i &gt;= 0">
+          <xsl:when test="$i &gt;= 1">
             <xsl:text>darkgreen</xsl:text>
           </xsl:when>
           <xsl:otherwise>
@@ -62,7 +64,7 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
-      <xsl:value-of select="z:format-signed($i, '0.00')"/>
+      <xsl:value-of select="format-number($i, '0.00')"/>
     </span>
   </xsl:function>
   <xsl:function name="z:pmp">


### PR DESCRIPTION
`z:index` painted a number green at or above zero and printed it with a sign. Its only two
callers are CPI and SPI, which are ratios of two non-negative amounts: they are never below
zero, so both were always green, and a project that had spent five times what it earned was
shown as `CPI: +0.20` in green.

One is the neutral point of a ratio, so that is what the colour compares against, and the sign
is gone because a ratio is not a delta.

Closes #758
