### PR TITLE
#759: name a week the way the calendar names it

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -163,6 +163,32 @@ class TestAwards < Minitest::Test
     assert_equal('true', xml.xpath('/r/text()').to_s, xml)
   end
 
+  def test_names_the_week_across_new_year
+    xml = xslt(
+      "<r><xsl:apply-templates select='/' mode='awards'/></r>",
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>28</days_of_running_balance>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <who>1</who>
+          <who_name>jeff</who_name>
+          <award>10</award>
+          <when>2026-01-15T00:00:00Z</when>
+        </f>
+      </fb>
+      ',
+      'today' => '2026-01-19T00:00:00Z'
+    )
+    th = xml.xpath('//thead/tr/th[3]').first
+    assert_equal('w1', th.text.strip, xml)
+    assert_includes(th['title'], 'Week #1 in 2026', xml)
+  end
+
   def test_fn_award
     {
       42 => ['darkgreen', '+42'],

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -214,12 +214,13 @@
             <th class="right sorter">
               <xsl:variable name="week" select="xs:integer(.)"/>
               <xsl:variable name="d" select="xs:dateTime($today) - xs:dayTimeDuration(concat('P', ($weeks - $week) * 7, 'D'))"/>
-              <xsl:variable name="w" select="xs:integer(format-date(xs:date($d), '[W]'))"/>
+              <xsl:variable name="iso" select="z:iso-week($d)"/>
+              <xsl:variable name="w" select="xs:integer(substring($iso, 7))"/>
               <xsl:attribute name="title">
                 <xsl:text>Week #</xsl:text>
                 <xsl:value-of select="$w"/>
                 <xsl:text> in </xsl:text>
-                <xsl:value-of select="substring(xs:string(xs:date($d)), 1, 4)"/>
+                <xsl:value-of select="substring($iso, 1, 4)"/>
                 <xsl:text>, starting on Monday </xsl:text>
                 <xsl:value-of select="z:monday($week)"/>
               </xsl:attribute>

--- a/xsl/dot.xsl
+++ b/xsl/dot.xsl
@@ -39,12 +39,13 @@
             <th class="right">
               <xsl:variable name="week" select="xs:integer(.)"/>
               <xsl:variable name="d" select="xs:dateTime($today) - xs:dayTimeDuration(concat('P', ($weeks - $week) * 7, 'D'))"/>
-              <xsl:variable name="w" select="xs:integer(format-date(xs:date($d), '[W]'))"/>
+              <xsl:variable name="iso" select="z:iso-week($d)"/>
+              <xsl:variable name="w" select="xs:integer(substring($iso, 7))"/>
               <xsl:attribute name="title">
                 <xsl:text>Week #</xsl:text>
                 <xsl:value-of select="$w"/>
                 <xsl:text> in </xsl:text>
-                <xsl:value-of select="substring(xs:string(xs:date($d)), 1, 4)"/>
+                <xsl:value-of select="substring($iso, 1, 4)"/>
                 <xsl:text>, starting on Monday </xsl:text>
                 <xsl:value-of select="z:monday($week)"/>
               </xsl:attribute>


### PR DESCRIPTION
The header used `format-date(..., '[W]')` with the calendar year of the date, and neither is the
ISO week the column covers. With `today` at 2026-01-19 and the default window, the first column
came out as `w53` "in 2025" while it is the first week of 2026, and `w1` never appeared, so the
headers jumped from 53 to 2. `dot.xsl` built the same title the same way.

`z:iso-week` already computes this correctly for the weekly charts, so both headers read it now.

Closes #759
