### PR TITLE
#760: read the moment of a fact that carries more than one

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -148,7 +148,7 @@ class TestAwards < Minitest::Test
 
   def test_fn_in_week
     xml = xslt(
-      '<r><xsl:value-of select="z:in-week(\'2024-09-20T04:04:04Z\', 1)"/></r>',
+      '<r><xsl:value-of select="z:in-week(xs:dateTime(\'2024-09-20T04:04:04Z\'), 1)"/></r>',
       '
       <fb>
         <f>

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -38,6 +38,37 @@ class TestVitals < Minitest::Test
     end
   end
 
+  def test_renders_a_fact_that_has_two_moments
+    xml = xslt(
+      "<r><xsl:apply-templates select='/' mode='awards'/></r>",
+      '
+      <fb>
+        <f>
+          <what>pmp</what>
+          <area>hr</area>
+          <days_of_running_balance>7</days_of_running_balance>
+        </f>
+        <f>
+          <what>something</what>
+          <who>5</who>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <who>1</who>
+          <who_name>jeff</who_name>
+          <award>10</award>
+          <when>
+            <v t="T">2024-07-02T00:00:00Z</v>
+            <v t="T">2024-07-03T00:00:00Z</v>
+          </when>
+        </f>
+      </fb>
+      ',
+      'today' => '2024-07-05T00:00:00Z'
+    )
+    assert_equal(1, xml.xpath('//tbody/tr[not(@class)]').size, xml)
+  end
+
   def test_fn_pmp
     xml = xslt(
       '<r><xsl:value-of select="z:pmp(\'hr\', \'foo\', \'bar\')"/></r>',

--- a/xsl/assessment.xsl
+++ b/xsl/assessment.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="xs">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:template match="/" mode="assessment">
     <xsl:apply-templates select="/fb/f[what='latest-assessment']"/>
   </xsl:template>
@@ -20,9 +20,9 @@
             <xsl:value-of select="when"/>
           </xsl:attribute>
           <xsl:attribute name="title">
-            <xsl:value-of select="xs:date(xs:dateTime(when))"/>
+            <xsl:value-of select="xs:date(z:when(when))"/>
           </xsl:attribute>
-          <xsl:value-of select="xs:date(xs:dateTime(when))"/>
+          <xsl:value-of select="xs:date(z:when(when))"/>
         </time>
       </pre>
       <xsl:if test="total &gt; 1">

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -8,7 +8,7 @@
   <xsl:variable name="days" select="z:pmp('hr', 'days_of_running_balance', '28')"/>
   <xsl:variable name="weeks" select="xs:integer(ceiling(xs:float($days) div 7))"/>
   <xsl:variable name="since" select="xs:dateTime($today) - xs:dayTimeDuration(concat('P', $days, 'D'))"/>
-  <xsl:variable name="facts" select="$fb/f[award and xs:dateTime(when) &gt; $since and is_human = 1]"/>
+  <xsl:variable name="facts" select="$fb/f[award and z:when(when) &gt; $since and is_human = 1]"/>
   <xsl:function name="z:monday" as="xs:date">
     <!--
     Takes week number (e.g. 4) and returns ISO-8601 date of the
@@ -28,11 +28,11 @@
     Takes date and week number (e.g. 4) and returns 'true' if the date is
     inside the week. Weeks counting starts from the n-th week before today.
     -->
-    <xsl:param name="when" as="xs:string"/>
+    <xsl:param name="when" as="xs:dateTime?"/>
     <xsl:param name="week" as="xs:integer"/>
     <xsl:variable name="monday" select="xs:dateTime(z:monday($week))"/>
     <xsl:variable name="sunday" select="$monday + xs:dayTimeDuration('P7D')"/>
-    <xsl:value-of select="xs:dateTime($when) &gt; $monday and xs:dateTime($when) &lt; $sunday"/>
+    <xsl:value-of select="$when &gt; $monday and $when &lt; $sunday"/>
   </xsl:function>
   <xsl:function name="z:payables">
     <!--
@@ -54,7 +54,7 @@
           </xsl:if>
         </xsl:for-each>
         <td class="right ff">
-          <xsl:variable name="accumulated" select="xs:integer(sum($fb/f[award and is_human = 1 and who_name=$name and xs:dateTime(when) &gt; xs:dateTime($rec/since)]/award))"/>
+          <xsl:variable name="accumulated" select="xs:integer(sum($fb/f[award and is_human = 1 and who_name=$name and z:when(when) &gt; xs:dateTime($rec/since)]/award))"/>
           <xsl:variable name="delta" select="$accumulated - xs:integer($rec/awarded)"/>
           <xsl:variable name="payable" select="$accumulated - xs:integer($rec/awarded) + xs:integer($rec/balance)"/>
           <xsl:attribute name="title">
@@ -279,7 +279,7 @@
           </td>
           <xsl:for-each select="1 to $weeks">
             <xsl:variable name="week" select="."/>
-            <xsl:copy-of select="z:td-award(xs:integer(sum($facts[z:in-week(when, $week)]/award)))"/>
+            <xsl:copy-of select="z:td-award(xs:integer(sum($facts[z:in-week(z:when(when), $week)]/award)))"/>
           </xsl:for-each>
           <xsl:copy-of select="z:td-award(xs:integer(sum($facts/award)))"/>
           <xsl:if test="$fb/f[what='reconciliation']">
@@ -325,7 +325,7 @@
       </td>
       <xsl:for-each select="1 to $weeks">
         <xsl:variable name="week" select="."/>
-        <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who_name=$name and z:in-week(when, $week)]/award)))"/>
+        <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who_name=$name and z:in-week(z:when(when), $week)]/award)))"/>
       </xsl:for-each>
       <xsl:copy-of select="z:td-award(xs:integer(sum($facts[who_name=$name]/award)))"/>
       <xsl:if test="$fb/f[what='reconciliation']">
@@ -346,8 +346,8 @@
           <xsl:variable name="week" select="."/>
           <td class="right">
             <xsl:choose>
-              <xsl:when test="$fb/f[what='reconciliation' and who=$id and z:in-week(when, $week)]">
-                <xsl:for-each select="$fb/f[what='reconciliation' and who=$id and z:in-week(when, $week)]">
+              <xsl:when test="$fb/f[what='reconciliation' and who=$id and z:in-week(z:when(when), $week)]">
+                <xsl:for-each select="$fb/f[what='reconciliation' and who=$id and z:in-week(z:when(when), $week)]">
                   <xsl:if test="position() &gt; 1">
                     <br/>
                   </xsl:if>
@@ -360,7 +360,7 @@
                       <xsl:text> points, a payout of </xsl:text>
                       <xsl:value-of select="xs:integer(payout)"/>
                       <xsl:text> points has been made on </xsl:text>
-                      <xsl:value-of select="xs:date(xs:dateTime(when))"/>
+                      <xsl:value-of select="xs:date(z:when(when))"/>
                       <xsl:text>, making the amount payable equal to </xsl:text>
                       <xsl:value-of select="balance"/>
                     </xsl:attribute>
@@ -399,7 +399,7 @@
           <xsl:variable name="week" select="."/>
           <td class="ff right">
             <xsl:choose>
-              <xsl:when test="z:in-week($fact/when, $week)">
+              <xsl:when test="z:in-week(z:when($fact/when), $week)">
                 <xsl:choose>
                   <xsl:when test="$fact/href and starts-with($fact/href, 'https://github.com/')">
                     <a>

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -3,12 +3,13 @@
 * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/2000/svg" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" exclude-result-prefixes="xs">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://www.w3.org/2000/svg" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
+  <xsl:include href="when.xsl"/>
   <xsl:output method="xml" omit-xml-declaration="yes"/>
   <xsl:param name="today" as="xs:string"/>
   <xsl:template match="/fb">
     <xsl:variable name="since" select="xs:dateTime($today) - xs:dayTimeDuration('P256D')" as="xs:dateTime"/>
-    <xsl:variable name="facts" select=".//f[xs:dateTime(when) &gt; $since and award]"/>
+    <xsl:variable name="facts" select=".//f[z:when(when) &gt; $since and award]"/>
     <xsl:variable name="sum" select="sum($facts/award)" as="xs:double"/>
     <xsl:variable name="count" select="count($facts)" as="xs:integer"/>
     <xsl:variable name="avg">

--- a/xsl/dot.xsl
+++ b/xsl/dot.xsl
@@ -4,7 +4,7 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
-  <xsl:variable name="dot_facts" select="/fb/f[what='dimensions-of-terrain' and xs:dateTime(when) &gt; $since]"/>
+  <xsl:variable name="dot_facts" select="/fb/f[what='dimensions-of-terrain' and z:when(when) &gt; $since]"/>
   <xsl:template match="/" mode="dot">
     <xsl:choose>
       <xsl:when test="empty($dot_facts)">
@@ -64,7 +64,7 @@
             </td>
             <xsl:for-each select="1 to $weeks">
               <xsl:variable name="week" select="xs:integer(.)"/>
-              <xsl:variable name="f" select="$dot_facts[z:in-week(when, $week)][last()]"/>
+              <xsl:variable name="f" select="$dot_facts[z:in-week(z:when(when), $week)][last()]"/>
               <td class="ff right">
                 <xsl:choose>
                   <xsl:when test="$f">

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -25,11 +25,11 @@
     <xsl:param name="title" as="xs:string"/>
     <xsl:param name="colors" as="xs:string" select="'n_composite:orange'"/>
     <xsl:param name="before"/>
-    <xsl:variable name="raw" select="/fb/f[what=$what and xs:dateTime(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P180D'))]"/>
+    <xsl:variable name="raw" select="/fb/f[what=$what and z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P180D'))]"/>
     <xsl:variable name="facts">
-      <xsl:for-each-group select="$raw" group-by="z:iso-week(xs:dateTime(when))">
+      <xsl:for-each-group select="$raw" group-by="z:iso-week(z:when(when))">
         <xsl:for-each select="current-group()">
-          <xsl:sort select="xs:dateTime(when)" order="ascending"/>
+          <xsl:sort select="z:when(when)" order="ascending"/>
           <xsl:if test="position() = last()">
             <xsl:copy-of select="."/>
           </xsl:if>
@@ -66,7 +66,7 @@
               <xsl:text>,</xsl:text>
             </xsl:if>
             <xsl:text>'</xsl:text>
-            <xsl:value-of select="format-date(xs:date(xs:dateTime(when)), '[M1]/[D1]')"/>
+            <xsl:value-of select="format-date(xs:date(z:when(when)), '[M1]/[D1]')"/>
             <xsl:text>'</xsl:text>
           </xsl:for-each>
           <xsl:text>],fullDates:[</xsl:text>
@@ -76,7 +76,7 @@
               <xsl:text>,</xsl:text>
             </xsl:if>
             <xsl:text>'</xsl:text>
-            <xsl:value-of select="format-date(xs:date(xs:dateTime(when)), '[D1] [MN,*-3] [Y]')"/>
+            <xsl:value-of select="format-date(xs:date(z:when(when)), '[D1] [MN,*-3] [Y]')"/>
             <xsl:text>'</xsl:text>
           </xsl:for-each>
           <xsl:text>],</xsl:text>

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -5,6 +5,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
   <xsl:include href="script-with-cdata.xsl"/>
+  <xsl:include href="when.xsl"/>
   <xsl:output method="xml" omit-xml-declaration="yes" encoding="UTF-8" indent="yes"/>
   <xsl:param name="today" as="xs:string"/>
   <xsl:param name="css" as="xs:string"/>
@@ -143,7 +144,7 @@
         <meta charset="UTF-8"/>
         <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
         <xsl:variable name="description">
-          <xsl:variable name="facts" select="$fb/f[xs:dateTime(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award]"/>
+          <xsl:variable name="facts" select="$fb/f[z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award]"/>
           <xsl:variable name="count" select="count($facts)" as="xs:integer"/>
           <xsl:variable name="avg" as="xs:double" select="if ($count = 0) then xs:double('0') else sum($facts/award) div $count"/>
           <xsl:text>The "</xsl:text>

--- a/xsl/when.xsl
+++ b/xsl/when.xsl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
+  <xsl:function name="z:when" as="xs:dateTime?">
+    <!--
+    Reads the moment of a fact out of its "when" property. A property of a
+    fact is a set of values, so it may hold more than one, and the XML then
+    carries them as "v" children instead of as text. The earliest of them is
+    the answer, so that a fact written twice still lands in one place instead
+    of taking the whole page down with a type error. A fact with no "when"
+    at all answers with nothing, the way reading the property directly did.
+    -->
+    <xsl:param name="w" as="element()*"/>
+    <xsl:sequence select="min(for $v in ($w/v, $w[not(v)]) return xs:dateTime($v))"/>
+  </xsl:function>
+</xsl:stylesheet>


### PR DESCRIPTION
A property of a fact is a set of values, so `when` may hold two, and the XML then carries them as
`v` children. Every stylesheet read it as a scalar, so `xs:dateTime(when)` got the two timestamps
glued together and raised `FORG0001`. Saxon exits non-zero, the entry script runs under `set -e`,
and the action produced no HTML at all, with a message naming neither the fact nor the property.
One such fact was enough, and it can come from any judge, including one in the user's own
repository.

`z:when` reads that property in one place and answers with the earliest value it holds, so a fact
written twice lands in one week instead of taking the page down. Every reader goes through it,
and `z:in-week` now takes the moment rather than the node, so the two cannot drift apart.

`badge.xsl` and `assessment.xsl` gained the `z` namespace, which they did not declare before.

Closes #760
