### PR TITLE
#797: keep the bylaws until there are new ones

### DIFF
--- a/judges/add-bylaws-html/add-bylaws-html.rb
+++ b/judges/add-bylaws-html/add-bylaws-html.rb
@@ -18,8 +18,8 @@ f&.all_properties&.each do |prop|
   htmls << Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(escape_html: true)).render(md)
   par += 1
 end
-Fbe.fb.query('(eq what "bylaws")').delete!
 return if htmls.empty?
+Fbe.fb.query('(eq what "bylaws")').delete!
 s = Fbe.fb.insert
 s.what = 'bylaws'
 s.html = htmls.join

--- a/test/judges/test_add_bylaws_html.rb
+++ b/test/judges/test_add_bylaws_html.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestAddBylawsHtml < Minitest::Test
+  def test_keeps_the_bylaws_when_there_is_nothing_to_build
+    fb = Factbase.new
+    pmp = fb.insert
+    pmp.what = 'pmp'
+    pmp.area = 'hr'
+    pmp.hr_bonus = '(award (give 10 "for nothing"))'
+    load_it('add-bylaws-html', fb)
+    assert_equal(1, fb.query('(eq what "bylaws")').each.to_a.size, fb.to_json)
+    fb.query('(and (eq what "pmp") (eq area "hr"))').delete!
+    quiet = fb.insert
+    quiet.what = 'pmp'
+    quiet.area = 'hr'
+    quiet.hr_balance = 42
+    load_it('add-bylaws-html', fb)
+    assert_equal(1, fb.query('(eq what "bylaws")').each.to_a.size, fb.to_json)
+  end
+end

--- a/test/judges/test_add_bylaws_html.rb
+++ b/test/judges/test_add_bylaws_html.rb
@@ -9,18 +9,36 @@ require_relative '../test__helper'
 class TestAddBylawsHtml < Minitest::Test
   def test_keeps_the_bylaws_when_there_is_nothing_to_build
     fb = Factbase.new
-    pmp = fb.insert
-    pmp.what = 'pmp'
-    pmp.area = 'hr'
-    pmp.hr_bonus = '(award (give 10 "for nothing"))'
+    with_formula(fb)
     load_it('add-bylaws-html', fb)
-    assert_equal(1, fb.query('(eq what "bylaws")').each.to_a.size, fb.to_json)
+    assert_equal(1, bylaws(fb), fb.to_json)
+    without_formula(fb)
+    load_it('add-bylaws-html', fb)
+    assert_equal(1, bylaws(fb), fb.to_json)
+    with_formula(fb)
+    load_it('add-bylaws-html', fb)
+    assert_equal(1, bylaws(fb), fb.to_json)
+  end
+
+  private
+
+  def bylaws(fb)
+    fb.query('(eq what "bylaws")').each.to_a.size
+  end
+
+  def with_formula(fb)
     fb.query('(and (eq what "pmp") (eq area "hr"))').delete!
-    quiet = fb.insert
-    quiet.what = 'pmp'
-    quiet.area = 'hr'
-    quiet.hr_balance = 42
-    load_it('add-bylaws-html', fb)
-    assert_equal(1, fb.query('(eq what "bylaws")').each.to_a.size, fb.to_json)
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'hr'
+    f.hr_bonus = '(award (give 10 "for nothing"))'
+  end
+
+  def without_formula(fb)
+    fb.query('(and (eq what "pmp") (eq area "hr"))').delete!
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'hr'
+    f.hr_balance = 42
   end
 end


### PR DESCRIPTION
The judge deleted the old bylaws before it knew whether it had anything to put in their place, so a missing `pmp/hr` fact, or one whose properties carry no `(award` formula, wiped what the previous run had built and left the page showing "There is no information about bylaws."

The delete now happens after the empty check, which is the order `latest-assessment` already uses.

Closes #797
