### PR TITLE
#798: break the line before the assessment date

### DIFF
--- a/test/pages/test_assessment.rb
+++ b/test/pages/test_assessment.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require_relative '../test__helper'
+
+class TestAssessment < Minitest::Test
+  def test_breaks_the_line_before_the_date
+    xml = xslt(
+      "<xsl:apply-templates select='/' mode='assessment'/>",
+      "<fb><f><what>latest-assessment</what><text>The project is healthy.</text>
+      <when>2026-09-01T00:00:00Z</when><total>1</total></f></fb>"
+    )
+    pre = xml.xpath("//*[local-name()='pre']").text
+    refute_includes(pre, 'healthy.Last assessed on', pre)
+    assert_includes(pre, "healthy.\nLast assessed on", pre)
+  end
+end

--- a/xsl/assessment.xsl
+++ b/xsl/assessment.xsl
@@ -14,7 +14,7 @@
       </h2>
       <pre>
         <xsl:value-of select="text"/>
-        <xsl:text>Last assessed on </xsl:text>
+        <xsl:text>&#10;Last assessed on </xsl:text>
         <time class="relative-time">
           <xsl:attribute name="datetime">
             <xsl:value-of select="when"/>

--- a/xsl/assessment.xsl
+++ b/xsl/assessment.xsl
@@ -14,7 +14,8 @@
       </h2>
       <pre>
         <xsl:value-of select="text"/>
-        <xsl:text>&#10;Last assessed on </xsl:text>
+        <xsl:text>
+Last assessed on </xsl:text>
         <time class="relative-time">
           <xsl:attribute name="datetime">
             <xsl:value-of select="when"/>


### PR DESCRIPTION
The assessment text and the sentence that dates it went into the same `<pre>` with nothing between them, so they came out as one run-on line. A `<pre>` keeps the whitespace it is given, so nothing downstream repaired it.

Closes #798
