### PR TITLE
#810: assert what the badge renders, not that the file has a line

### DIFF
--- a/entries/renders-svg-badge.sh
+++ b/entries/renders-svg-badge.sh
@@ -19,4 +19,11 @@ env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep  '' output/test-badge.svg
+badge=output/test-badge.svg
+
+grep -q "<svg" "${badge}"
+grep -q 'width="93"' "${badge}"
+grep -q 'height="20"' "${badge}"
+grep -q 'fill="#e05d44"' "${badge}"
+grep -q ">avg<" "${badge}"
+grep -qE ">[+]0(\.0)?<" "${badge}"


### PR DESCRIPTION
Fixes #810

The only assertion in the badge entry test was `grep  ''`, an empty pattern that matches any line of any file. It passed as long as the SVG was not empty, so none of the branches in `badge.xsl` was covered: not the width picked from `abs($avg)`, not the fill picked from `$avg`, not the rendered average, not even that the output is an SVG.

The factbase the test builds is one bare fact, so no fact carries an `award`, `$count` is 0 and `$avg` is `0.0`. Running `badge.xsl` on that input through Saxon gives `width="93"` (the `otherwise` right-hand width of 43 plus the fixed 50), `fill="#e05d44"` (the `otherwise` colour, since 0 is not above 0), the `avg` label and the text `+0`. Those are what the test now checks.

The average is matched as `>[+]0(\.0)?<` on purpose: #766 is still open about the decimal being dropped there, and this test should keep passing when that is fixed.
