### PR TITLE
Pin Docker Ruby dependencies to Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY Makefile /home
 COPY makes /home/makes
 COPY .stylelintrc.json /home
 COPY Gemfile /home
+COPY Gemfile.lock /home
 COPY html-minifier-config.json /home
 COPY judges /home/judges
 COPY sass /home/sass

--- a/makes/install.sh
+++ b/makes/install.sh
@@ -6,6 +6,7 @@ set -e -o pipefail
 
 OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
 
+bundle config set --local frozen true
 bundle install
 if [ "${OS_NAME}" = "darwin" ]; then
     brew install tidy-html5


### PR DESCRIPTION
## What's changed

The Docker image now copies `Gemfile.lock` before dependency installation, and the install script enables Bundler's frozen mode. Docker builds therefore use the dependency graph tested by the repository instead of resolving a fresh graph from RubyGems.

## Why

The previous image copied only `Gemfile` and ran an unconstrained `bundle install`. That allowed the published action to contain gem versions different from CI and made builds change without a source change. Frozen mode also makes Gemfile/lockfile drift fail during the image build.

## Verification

- `git diff --check`
- Reviewed the Docker build order: the lockfile is present before `makes/install.sh` runs.

Closes #814
