### PR TITLE
Avoid duplicate script template includes

### DIFF
--- a/js/outdated.js
+++ b/js/outdated.js
@@ -58,22 +58,18 @@ function formatRelativeTime(diffInMs, startDate) {
  * Displays a warning message if the page is outdated
  */
 function displayOutdatedWarning() {
-  const time = Date.parse($("#generated-time").attr("datetime"));
-  if (isNaN(time)) {
-    console.error("Could not parse the generated time");
-    return;
-  }
-  const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
-  const warning = $("#page-outdated-warning");
-  if (hours > OUTDATED_THRESHOLD_HOURS) {
-    const message = `This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.`;
-    if (warning.length === 0) {
-      $('footer').prepend(`<p id="page-outdated-warning" class='red'>${message}</p>`);
-    } else {
-      warning.text(message);
+  if ($("#page-outdated-warning").length === 0) {
+    const time = Date.parse($("#generated-time").attr("datetime"));
+    if (isNaN(time)) {
+      console.error("Could not parse the generated time");
+      return;
     }
-  } else if (warning.length > 0) {
-    warning.remove();
+    const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
+    if (hours > OUTDATED_THRESHOLD_HOURS) {
+      $('footer').prepend(
+        `<p id="page-outdated-warning" class='red'>This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.</p>`
+      );
+    }
   }
 }
 

--- a/js/outdated.js
+++ b/js/outdated.js
@@ -58,18 +58,22 @@ function formatRelativeTime(diffInMs, startDate) {
  * Displays a warning message if the page is outdated
  */
 function displayOutdatedWarning() {
-  if ($("#page-outdated-warning").length === 0) {
-    const time = Date.parse($("#generated-time").attr("datetime"));
-    if (isNaN(time)) {
-      console.error("Could not parse the generated time");
-      return;
+  const time = Date.parse($("#generated-time").attr("datetime"));
+  if (isNaN(time)) {
+    console.error("Could not parse the generated time");
+    return;
+  }
+  const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
+  const warning = $("#page-outdated-warning");
+  if (hours > OUTDATED_THRESHOLD_HOURS) {
+    const message = `This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.`;
+    if (warning.length === 0) {
+      $('footer').prepend(`<p id="page-outdated-warning" class='red'>${message}</p>`);
+    } else {
+      warning.text(message);
     }
-    const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
-    if (hours > OUTDATED_THRESHOLD_HOURS) {
-      $('footer').prepend(
-        `<p id="page-outdated-warning" class='red'>This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.</p>`
-      );
-    }
+  } else if (warning.length > 0) {
+    warning.remove();
   }
 }
 

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -4,7 +4,6 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
-  <xsl:include href="script-with-cdata.xsl"/>
   <xsl:variable name="days" select="z:pmp('hr', 'days_of_running_balance', '28')"/>
   <xsl:variable name="weeks" select="xs:integer(ceiling(xs:float($days) div 7))"/>
   <xsl:variable name="since" select="xs:dateTime($today) - xs:dayTimeDuration(concat('P', $days, 'D'))"/>

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -4,7 +4,6 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:z="https://www.zerocracy.com" version="2.0" exclude-result-prefixes="xs z">
-  <xsl:include href="script-with-cdata.xsl"/>
   <xsl:function name="z:iso-week" as="xs:string">
     <xsl:param name="dt" as="xs:dateTime"/>
     <xsl:variable name="d" select="xs:date($dt)"/>


### PR DESCRIPTION
## What's changed

`script-with-cdata.xsl` is now included only by the top-level `vitals.xsl` stylesheet. The redundant includes were removed from `awards.xsl` and `qo-section.xsl`.

## Why

Both modules are imported by `vitals.xsl`, so the template was loaded three times for every vitals render. Saxon emitted an `SXWN9019` warning and maintained multiple import-precedence copies of the same named template. Keeping one top-level include removes the warning and leaves one unambiguous definition for all call sites.

## Verification

- `git diff --check`
- Confirmed both modules are imported through `vitals.xsl`, which retains the include.

Closes #807
