### PR TITLE
Refresh outdated page warning text

### DIFF
--- a/js/outdated.js
+++ b/js/outdated.js
@@ -58,18 +58,22 @@ function formatRelativeTime(diffInMs, startDate) {
  * Displays a warning message if the page is outdated
  */
 function displayOutdatedWarning() {
-  if ($("#page-outdated-warning").length === 0) {
-    const time = Date.parse($("#generated-time").attr("datetime"));
-    if (isNaN(time)) {
-      console.error("Could not parse the generated time");
-      return;
+  const time = Date.parse($("#generated-time").attr("datetime"));
+  if (isNaN(time)) {
+    console.error("Could not parse the generated time");
+    return;
+  }
+  const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
+  const warning = $("#page-outdated-warning");
+  if (hours > OUTDATED_THRESHOLD_HOURS) {
+    const message = `This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.`;
+    if (warning.length === 0) {
+      $('footer').prepend(`<p id="page-outdated-warning" class='red'>${message}</p>`);
+    } else {
+      warning.text(message);
     }
-    const hours = Math.floor((Date.now() - time) / TIME_UNITS.HOUR);
-    if (hours > OUTDATED_THRESHOLD_HOURS) {
-      $('footer').prepend(
-        `<p id="page-outdated-warning" class='red'>This page was generated ${hours} ${hours === 1 ? 'hour' : 'hours'} ago. The information is most probably outdated.</p>`
-      );
-    }
+  } else if (warning.length > 0) {
+    warning.remove();
   }
 }
 


### PR DESCRIPTION
## What's changed

The outdated-page warning is recalculated on every timer tick. Its text is updated as the page ages, and the warning is removed if the page becomes fresh again.

## Why

The previous function returned as soon as the warning existed. A page that stayed open therefore displayed the age from the first check forever, while the relative timestamps around it continued changing. The warning could also remain after a refreshed page became current.

## Verification

- `git diff --check`
- The existing one-minute timer now updates or removes the existing warning element instead of returning early.

Closes #806
