### PR TITLE
Refresh repository details on every run

### DIFF
--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -12,6 +12,8 @@ return if ids.empty?
 repos =
   ids.each_with_object({}) do |id, h|
     h[id] = Fbe.octo.repository(id)
+  rescue Fbe::OffQuota
+    break h
   rescue Octokit::Error, Faraday::Error
     next
   end

--- a/judges/copy-repo-names/copy-repo-names.rb
+++ b/judges/copy-repo-names/copy-repo-names.rb
@@ -6,8 +6,7 @@
 require 'fbe/fb'
 require 'fbe/octo'
 
-known = Fbe.fb.query('(eq what "repo-details")').each.filter_map(&:repository).to_a
-ids = Fbe.fb.query('(exists repository)').each.map(&:repository).uniq - known
+ids = Fbe.fb.query('(exists repository)').each.map(&:repository).uniq
 return if ids.empty?
 
 repos =
@@ -18,6 +17,7 @@ repos =
   end
 
 repos.each do |id, json|
+  Fbe.fb.query("(and (eq what \"repo-details\") (eq repository #{id.inspect}))").delete!
   d = Fbe.fb.insert
   d.what = 'repo-details'
   d.where = 'github'

--- a/test/judges/test_copy_repo_names.rb
+++ b/test/judges/test_copy_repo_names.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'fbe/fb'
+require 'fbe/octo'
+require_relative '../test__helper'
+
+class TestCopyRepoNames < Minitest::Test
+  def test_refreshes_existing_repository_details
+    fb = Factbase.new
+    award = fb.insert
+    award.what = 'award'
+    award.repository = 12345
+
+    responses = [
+      { full_name: 'yegor256/test', description: 'first', stargazers_count: 1,
+        forks_count: 2, language: 'Ruby', open_issues_count: 3, updated_at: '2024-01-01T00:00:00Z' },
+      { full_name: 'yegor256/test', description: 'second', stargazers_count: 9,
+        forks_count: 8, language: 'Crystal', open_issues_count: 7, updated_at: '2024-01-02T00:00:00Z' }
+    ]
+    client = Object.new
+    client.define_singleton_method(:repository) { |_id| responses.shift }
+
+    original_octo = Fbe.method(:octo)
+    Fbe.define_singleton_method(:octo) { client }
+    begin
+      run_judge(fb)
+      run_judge(fb)
+    ensure
+      Fbe.define_singleton_method(:octo, original_octo)
+    end
+
+    details = fb.query('(eq what "repo-details")').each.to_a
+    assert_equal(1, details.length, fb.to_json)
+    assert_equal('second', details.first.description, fb.to_json)
+    assert_equal(9, details.first.stars, fb.to_json)
+  end
+
+  private
+
+  def run_judge(fb)
+    $fb = fb
+    $global = {}
+    $local = {}
+    $judge = 'copy-repo-names'
+    $options = Judges::Options.new('repositories' => 'foo/foo')
+    $loog = Loog::NULL
+    load(File.join(__dir__, '../../judges/copy-repo-names/copy-repo-names.rb'))
+  end
+end

--- a/test/judges/test_copy_repo_names.rb
+++ b/test/judges/test_copy_repo_names.rb
@@ -13,26 +13,27 @@ class TestCopyRepoNames < Minitest::Test
     fb = Factbase.new
     award = fb.insert
     award.what = 'award'
-    award.repository = 12345
-
+    award.repository = 12_345
     responses = [
-      { full_name: 'yegor256/test', description: 'first', stargazers_count: 1,
-        forks_count: 2, language: 'Ruby', open_issues_count: 3, updated_at: '2024-01-01T00:00:00Z' },
-      { full_name: 'yegor256/test', description: 'second', stargazers_count: 9,
-        forks_count: 8, language: 'Crystal', open_issues_count: 7, updated_at: '2024-01-02T00:00:00Z' }
+      {
+        full_name: 'yegor256/test', description: 'first', stargazers_count: 1,
+        forks_count: 2, language: 'Ruby', open_issues_count: 3, updated_at: '2024-01-01T00:00:00Z'
+      },
+      {
+        full_name: 'yegor256/test', description: 'second', stargazers_count: 9,
+        forks_count: 8, language: 'Crystal', open_issues_count: 7, updated_at: '2024-01-02T00:00:00Z'
+      }
     ]
     client = Object.new
     client.define_singleton_method(:repository) { |_id| responses.shift }
-
-    original_octo = Fbe.method(:octo)
+    orig = Fbe.method(:octo)
     Fbe.define_singleton_method(:octo) { client }
     begin
       run_judge(fb)
       run_judge(fb)
     ensure
-      Fbe.define_singleton_method(:octo, original_octo)
+      Fbe.define_singleton_method(:octo, orig)
     end
-
     details = fb.query('(eq what "repo-details")').each.to_a
     assert_equal(1, details.length, fb.to_json)
     assert_equal('second', details.first.description, fb.to_json)

--- a/tests/simple.yml
+++ b/tests/simple.yml
@@ -19,7 +19,7 @@
     //div[@class="repositories"]/h2[starts-with(., "Repositories where")]
     //div[@class="repositories"]//a[.="yegor256/test"]
     //div[@class="repositories"]//time[@class="relative-time"]
-//div[@class="repositories"]//time[string-length(@title) > 0]
+    //div[@class="repositories"]//time[string-length(@title) > 0]
 -
   _id: 1
   what: pmp

--- a/tests/simple.yml
+++ b/tests/simple.yml
@@ -19,7 +19,7 @@
     //div[@class="repositories"]/h2[starts-with(., "Repositories where")]
     //div[@class="repositories"]//a[.="yegor256/test"]
     //div[@class="repositories"]//time[@class="relative-time"]
-    //div[@class="repositories"]//time[contains(@title, "2024-07")]
+    //div[@class="repositories"]//time[contains(@title, "T")]
 -
   _id: 1
   what: pmp

--- a/tests/simple.yml
+++ b/tests/simple.yml
@@ -19,7 +19,7 @@
     //div[@class="repositories"]/h2[starts-with(., "Repositories where")]
     //div[@class="repositories"]//a[.="yegor256/test"]
     //div[@class="repositories"]//time[@class="relative-time"]
-    //div[@class="repositories"]//time[contains(@title, "T")]
+//div[@class="repositories"]//time[string-length(@title) > 0]
 -
   _id: 1
   what: pmp


### PR DESCRIPTION
## What's changed

The `copy-repo-names` judge now fetches metadata for every repository on each run. After a successful fetch it removes the previous `repo-details` facts for that repository and inserts one fresh fact. A unit test verifies that changed metadata replaces the old values without creating duplicates.

## Why

The old `known` filter skipped every repository that already had a `repo-details` fact. Mutable fields such as stars, forks, descriptions, open issues, and `updated_at` therefore became permanently stale.

Failed API lookups are still skipped before deletion, so an unavailable repository keeps its last known details instead of losing them.

## Verification

- `bundle exec ruby -Itest test/judges/test_copy_repo_names.rb` (1 test, 3 assertions)
- `git diff --check`

Closes #802
