### PR TITLE
Mask GitHub tokens before command tracing

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -28,6 +28,11 @@ fi
 
 echo "The 'pages-action' ${VERSION} is running"
 
+github_token=$(printenv "INPUT_GITHUB-TOKEN" || true)
+if [ -n "${github_token}" ]; then
+    echo "::add-mask::${github_token}"
+fi
+
 if [ "${INPUT_VERBOSE}" == 'true' ]; then
     set -x
 fi
@@ -118,6 +123,15 @@ while IFS= read -r o; do
     v="${v%"${v##*[![:space:]]}"}"
     if [ "${v}" = "" ]; then
         continue
+    fi
+    if [[ "${v}" == "github_token="* ]]; then
+        if [ "${INPUT_VERBOSE}" == 'true' ]; then
+            set +x
+        fi
+        echo "::add-mask::${v#github_token=}"
+        if [ "${INPUT_VERBOSE}" == 'true' ]; then
+            set -x
+        fi
     fi
     options+=("--option=${v}")
 done <<< "${INPUT_OPTIONS}"


### PR DESCRIPTION
## What's changed

GitHub Actions mask commands are emitted for the `github-token` input before verbose tracing is enabled, and for `github_token=` values found in the options list before those options are expanded.

## Why

With `verbose: true`, Bash tracing prints the expanded `judges update` command. The previous `set +x` guard hid only the token assignment; the later command expansion still exposed the token in logs. Tokens supplied through `INPUT_OPTIONS` had the same risk.

Masking happens while tracing is disabled for the mask command itself, then tracing may safely resume because GitHub redacts the registered values wherever they appear in the log.

## Verification

- `bash -n entry.sh`
- `git diff --check`

Closes #813
