### PR TITLE
#800: take the latest reconciliation, not the last one in the XML

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -48,6 +48,54 @@ class TestAwards < Minitest::Test
     assert_equal('55', xml.xpath('/td/text()').to_s, xml)
   end
 
+  def test_fn_payables_picks_latest_reconciliation_not_last_in_xml
+    xml = xslt(
+      "<xsl:copy-of select=\"z:payables('dude')\"/>",
+      "
+      <fb>
+        <f>
+          <what>reconciliation</what>
+          <when>#{(Time.now - (60 * 60)).utc.iso8601}</when>
+          <since>#{(Time.now - (50 * 60 * 60)).utc.iso8601}</since>
+          <who_name>dude</who_name>
+          <awarded>100</awarded>
+          <payout>70</payout>
+          <balance>30</balance>
+        </f>
+        <f>
+          <what>reconciliation</what>
+          <when>#{(Time.now - (100 * 60 * 60)).utc.iso8601}</when>
+          <since>#{(Time.now - (1000 * 60 * 60)).utc.iso8601}</since>
+          <who_name>dude</who_name>
+          <awarded>0</awarded>
+          <payout>0</payout>
+          <balance>999</balance>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <when>#{(Time.now - (10 * 60 * 60)).utc.iso8601}</when>
+          <who_name>dude</who_name>
+          <award>40</award>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <when>#{(Time.now - (10 * 60 * 60)).utc.iso8601}</when>
+          <who_name>dude</who_name>
+          <award>60</award>
+        </f>
+        <f>
+          <is_human>1</is_human>
+          <when>#{Time.now.utc.iso8601}</when>
+          <who_name>dude</who_name>
+          <award>25</award>
+        </f>
+      </fb>
+      ",
+      'today' => (Time.now - (10 * 60 * 60)).utc.iso8601
+    )
+    assert_equal('55', xml.xpath('/td/text()').to_s, xml)
+  end
+
   def test_fn_payables_out_of_window
     xml = xslt(
       "<xsl:copy-of select=\"z:payables('dude')\"/>",

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -40,7 +40,21 @@
     in current awards and previously posted "reconciliation" facts.
     -->
     <xsl:param name="name" as="xs:string"/>
-    <xsl:variable name="rec" select="$fb/f[what='reconciliation' and who_name=$name][last()]"/>
+    <xsl:variable name="rec" as="element()?">
+      <!--
+      The latest reconciliation is the one with the greatest "when", not the
+      one that happens to sit last in the XML: facts may be imported or merged
+      out of chronological order. Read the moment through z:when, the same way
+      the awards below do, because a "when" written twice arrives as several
+      "v" children and casting it directly would fail.
+      -->
+      <xsl:for-each select="$fb/f[what='reconciliation' and who_name=$name]">
+        <xsl:sort select="z:when(when)" order="descending"/>
+        <xsl:if test="position() = 1">
+          <xsl:sequence select="."/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
     <xsl:choose>
       <xsl:when test="$rec">
         <xsl:for-each select="'awarded', 'since', 'balance', 'payout', 'when'">


### PR DESCRIPTION
Closes #800.

`z:payables` picked the reconciliation with `[last()]`, which is the last node in document order rather than the one with the greatest `when`. When facts arrive imported or merged out of chronological order, the Pay column was computed from an older payout while a newer reconciliation sat above it in the file.

The record is now chosen by sorting on the moment, descending.

### One deviation from the issue, on purpose

The issue suggests sorting on `xs:dateTime(when)`. This sorts on `z:when(when)` instead, the same reader the accumulation below it already uses. A fact's property is a set of values, so a `when` written twice arrives as several `v` children; casting that directly raises a type error, which is precisely what `z:when` was written to prevent:

> The earliest of them is the answer, so that a fact written twice still lands in one place instead of taking the whole page down with a type error.

Using the raw cast here would have swapped a wrong number for a broken page on exactly the malformed input this function is most likely to meet.

### Why the existing test could not catch it

`test_fn_payables_with_few_reconciliations` already has two reconciliations, but they sit in chronological order, so `[last()]` and "greatest `when`" agree and both answer `55`. The new test puts the newer record **first**, which is the only arrangement that separates the two readings.

Verified by reverting the XSL change while keeping the test:

- with this change: `make` green, `test_fn_payables_picks_latest_reconciliation_not_last_in_xml PASS`
- with the change reverted: `make` red, that test `FAIL`, while `test_fn_payables`, `test_fn_payables_out_of_window` and `test_fn_payables_with_few_reconciliations` all still passed — so the new test isolates this defect and nothing else regressed.

All 16 checks are green on a fork before opening this.