### PR TITLE
Sort award details by timestamp instant

### DIFF
--- a/test/pages/test_awards.rb
+++ b/test/pages/test_awards.rb
@@ -228,6 +228,35 @@ class TestAwards < Minitest::Test
     assert_includes(th['title'], 'Week #1 in 2026', xml)
   end
 
+  def test_sorts_award_details_by_instant
+    facts = [
+      ['utc', '2024-06-01T00:00:00Z'],
+      ['positive offset', '2024-06-01T00:30:00+03:00'],
+      ['negative offset', '2024-05-31T23:00:00-02:00']
+    ].map do |reason, timestamp|
+      "
+      <f>
+        <is_human>1</is_human>
+        <who>1</who>
+        <who_name>dude</who_name>
+        <award>10</award>
+        <why>#{reason}</why>
+        <when>#{timestamp}</when>
+      </f>
+      "
+    end.join
+    xml = xslt(
+      "<r><xsl:apply-templates select='/' mode='awards'/></r>",
+      "<fb>#{facts}</fb>",
+      'today' => '2024-06-02T00:00:00Z'
+    )
+    assert_equal(
+      ['positive offset', 'utc', 'negative offset'],
+      xml.xpath('//tr[contains(@class, "p_dude")]/td[2]').map(&:text),
+      xml
+    )
+  end
+
   def test_fn_award
     {
       42 => ['darkgreen', '+42'],

--- a/xsl/awards.xsl
+++ b/xsl/awards.xsl
@@ -387,7 +387,7 @@
       </tr>
     </xsl:if>
     <xsl:for-each select="$facts[who_name=$name]">
-      <xsl:sort select="when" data-type="text"/>
+      <xsl:sort select="z:when(when)"/>
       <xsl:variable name="fact" select="."/>
       <tr class="sub tablesorter-childRow p-table p_{$name}" style="display: none;">
         <td>


### PR DESCRIPTION
Fixes #822, reported by @gemshrine.

Award detail rows were sorted as raw timestamp strings. For example, June 1 at 00:30 +03:00 appeared after June 1 at 00:00 UTC, although it happened earlier. Sort using the existing `z:when` date-time value so detail rows follow chronological order across UTC offsets.

The regression renders the awards table through the real stylesheet with UTC, positive-offset and negative-offset timestamps, and asserts the displayed row order. It fails before the fix and passes afterward using the project's Saxon HE 9.8.0-5.

Validation: the focused awards suite passed 10 tests and 18 assertions. Full local `bundle exec rake` passed: 36 tests and 76 assertions, plus all 22 tests across six judges and clean lint. Two generated CSS/SVG artifact checks were skipped locally; Ruby coverage was 100%. The GitHub Docker integration test and 13 other checks passed. `make` and `validate-css` stopped during runner package installation with a Chrome package-index checksum mismatch, before project tests; [maintainer rerun requested](https://github.com/zerocracy/pages-action/pull/842#issuecomment-5606093233).

AI-assisted implementation and validation.
