### PR TITLE
Keep chart arrays in chronological timestamp order

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -58,6 +58,33 @@ class TestQoSection < Minitest::Test
     assert_equal('2024-W52', xml.xpath('//r/text()').to_s.strip)
   end
 
+  def test_chart_arrays_follow_timestamp_instants
+    facts = [
+      '<f><what>metric</what><when>2024-06-03T00:30:00+03:00</when>' \
+      '<n_value>10</n_value><n_other>100</n_other></f>',
+      '<f><what>metric</what><when>2024-06-02T23:00:00Z</when>' \
+      '<n_value>20</n_value><n_other>200</n_other></f>'
+    ]
+    series = { 'Value' => %w[10 20], 'Other' => %w[100 200] }
+    [facts, facts.reverse].each do |ordered|
+      xml = xslt(
+        "<r><xsl:call-template name='qo-section'>" \
+        "<xsl:with-param name='what' select=\"'metric'\"/>" \
+        "<xsl:with-param name='title' select=\"'Metric'\"/>" \
+        '</xsl:call-template></r>',
+        "<fb>#{ordered.join}</fb>",
+        'today' => '2024-06-04T00:00:00Z'
+      )
+      js = xml.xpath('//script').map(&:content).join
+      assert_equal(['6/3', '6/2'], js.match(/labels:\s*\[([^\]]+)\]/)[1].scan(/'([^']+)'/).flatten)
+      assert_equal(['3 JUN 2024', '2 JUN 2024'], js.match(/fullDates:\s*\[([^\]]+)\]/)[1].scan(/'([^']+)'/).flatten)
+      series.each do |label, expected|
+        data = js.match(/label:\s*'#{label}'.*?data:\s*\[([^\]]+)\]/m)[1]
+        assert_equal(expected, data.split(',').map(&:strip))
+      end
+    end
+  end
+
   def test_inline_js_syntax_in_generated_html
     xml = xslt(
       "<r><xsl:call-template name='qo-section'>" \

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -60,7 +60,7 @@
           <xsl:value-of select="$what"/>
           <xsl:text>',{labels:[</xsl:text>
           <xsl:for-each select="$facts/f">
-            <xsl:sort select="when" data-type="text" order="ascending"/>
+            <xsl:sort select="z:when(when)" order="ascending"/>
             <xsl:if test="position() &gt; 1">
               <xsl:text>,</xsl:text>
             </xsl:if>
@@ -70,7 +70,7 @@
           </xsl:for-each>
           <xsl:text>],fullDates:[</xsl:text>
           <xsl:for-each select="$facts/f">
-            <xsl:sort select="when" data-type="text" order="ascending"/>
+            <xsl:sort select="z:when(when)" order="ascending"/>
             <xsl:if test="position() &gt; 1">
               <xsl:text>,</xsl:text>
             </xsl:if>
@@ -107,7 +107,7 @@
             </xsl:if>
             <xsl:text>,data:[</xsl:text>
             <xsl:for-each select="$facts/f">
-              <xsl:sort select="when" data-type="text" order="ascending"/>
+              <xsl:sort select="z:when(when)" order="ascending"/>
               <xsl:if test="position() &gt; 1">
                 <xsl:text>,</xsl:text>
               </xsl:if>


### PR DESCRIPTION
Fixes #821, reported by @gemshrine.

The generated chart arrays sorted ISO timestamp text, so June 3 at 00:30 +03:00 appeared after June 2 at 23:00 UTC despite happening earlier. Sort labels, full dates and each dataset by the existing `z:when` date-time value.

The regression renders two samples that survive the existing weekly grouping, with two datasets and both input orders. It verifies chronological values and their corresponding labels/full dates. Weekly sampling and local date formatting are unchanged; the displayed local dates can differ from UTC date order.

Validation: the regression fails before the fix; the focused suite passes 10 tests and 20 assertions using the project's Saxon HE 9.8.0-5. Full local `bundle exec rake` passed: 36 tests, 83 assertions, all 22 tests across six judges and clean lint. Two generated CSS/SVG artifact checks were skipped locally; Ruby coverage was 100%. GitHub Docker integration and 13 other checks passed. `make` and `validate-css` failed before the build because the runner received a Chrome package-index checksum mismatch ([make](https://github.com/zerocracy/pages-action/actions/runs/34385293496), [CSS](https://github.com/zerocracy/pages-action/actions/runs/34385293413)). These need a maintainer rerun, as already requested for the same outage on #842.

AI-assisted implementation and validation.
