### PR TITLE
Choose latest user name mapping consistently

### DIFF
--- a/judges/copy-who-names/copy-who-names.rb
+++ b/judges/copy-who-names/copy-who-names.rb
@@ -11,7 +11,10 @@ names =
       (eq what "who-has-name")
       (exists who)
       (exists name))'
-  ).each.to_a.to_h { |f| [f.who, f.name] }
+  ).each.to_a.sort_by do |f|
+    stamp = f['when']&.first
+    [stamp.nil? ? 0 : 1, stamp || Time.at(0), f.name]
+  end.to_h { |f| [f.who, f.name] }
 
 Fbe.fb.query(
   '(and

--- a/judges/copy-who-names/dated-before-epoch.yml
+++ b/judges/copy-who-names/dated-before-epoch.yml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 1969-01-01T00:00:00Z
+  - what: who-has-name
+    who: 444
+    name: zzz
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/equal-time-first.yml
+++ b/judges/copy-who-names/equal-time-first.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 2024-01-02T00:00:00Z
+  - what: who-has-name
+    who: 444
+    name: aaa
+    when: 2024-01-01T22:00:00-02:00
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/equal-time-last.yml
+++ b/judges/copy-who-names/equal-time-last.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: aaa
+    when: 2024-01-01T22:00:00-02:00
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 2024-01-02T00:00:00Z
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/latest-first.yml
+++ b/judges/copy-who-names/latest-first.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 2024-02-01T00:00:00Z
+  - what: who-has-name
+    who: 444
+    name: oldname
+    when: 2024-01-01T00:00:00Z
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/latest-last.yml
+++ b/judges/copy-who-names/latest-last.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: oldname
+    when: 2024-01-01T00:00:00Z
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 2024-02-01T00:00:00Z
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/timezone-order.yml
+++ b/judges/copy-who-names/timezone-order.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: newname
+    when: 2024-01-01T23:30:00-02:00
+  - what: who-has-name
+    who: 444
+    name: oldname
+    when: 2024-01-02T00:30:00Z
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/undated-first.yml
+++ b/judges/copy-who-names/undated-first.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: newname
+  - what: who-has-name
+    who: 444
+    name: aaa
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]

--- a/judges/copy-who-names/undated-last.yml
+++ b/judges/copy-who-names/undated-last.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+input:
+  - what: something
+    who: 444
+  - what: something
+    who: 555
+  - what: who-has-name
+    who: 555
+    name: independent
+  - what: something
+    who: 444
+    who_name: preserved
+  - what: who-has-name
+    who: 444
+    name: aaa
+  - what: who-has-name
+    who: 444
+    name: newname
+expected:
+  - /fb/f[what='something' and who=444 and who_name='newname']
+  - /fb/f[what='something' and who=555 and who_name='independent']
+  - /fb/f[who_name='preserved']
+  - /fb[not(f[what='who-has-name' and who_name])]


### PR DESCRIPTION
Fixes #828.

When a user has multiple name mappings, importing an older mapping last can copy the outdated name into new facts. Select the mapping with the latest timestamp instead. Factbase timestamps compare by instant, including timezone offsets. Dated mappings take precedence over undated ones; equal timestamps and undated ties consistently select the lexicographically greatest name.

Adds eight judge fixtures covering reversed import orders, equivalent timestamps, timezone ordering, undated mappings and pre-epoch dates. Each also checks independent users, existing names and the exclusion of registry facts.

Validation: five new fixtures fail against the unchanged judge. With the fix, all 30 judge fixtures pass. Full local checks pass: 35 Ruby tests / 75 assertions, 100% Ruby coverage and clean RuboCop, using Ruby 3.3 and locked dependencies. Two existing generated-artifact checks are skipped locally. All 16 GitHub checks passed, including the full make target and Docker integration.
