### PR TITLE
Export all formats after updating the factbase

### DIFF
--- a/entries/exports-updated-factbase.sh
+++ b/entries/exports-updated-factbase.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+BUNDLE_GEMFILE="${SELF}/Gemfile"
+export BUNDLE_GEMFILE
+bundle exec judges eval test.fb \
+    "f = \$fb.insert; f.what = 'assessment'; f.text = 'Exported assessment'; f.when = Time.utc(2024, 7, 1)" > /dev/null
+
+env "GITHUB_WORKSPACE=$(pwd)" \
+    'INPUT_FACTBASE=test.fb' \
+    'INPUT_OUTPUT=output' \
+    'INPUT_VERBOSE=false' \
+    'INPUT_COLUMNS=what,text' \
+    'INPUT_OPTIONS=testing=yes' \
+    "${SELF}/entry.sh" 2>&1 | tee log.txt
+
+for format in yaml xml json html; do
+    grep 'latest-assessment' "output/test.${format}"
+done

--- a/entry.sh
+++ b/entry.sh
@@ -107,16 +107,6 @@ name=$(basename "${INPUT_FACTBASE}")
 name="${name%.*}"
 echo "The factbase name is: '${name}'"
 
-for f in yaml xml json html; do
-    ${JUDGES} "${gopts[@]}" print \
-        --format "${f}" \
-        --columns "${INPUT_COLUMNS}" \
-        --highlighted "${INPUT_HIGHLIGHTED}"\
-        --hidden "${INPUT_HIDDEN}" \
-        "${INPUT_FACTBASE}" \
-        "${INPUT_OUTPUT}/${name}.${f}"
-done
-
 declare -a options=()
 while IFS= read -r o; do
     v="${o#"${o%%[![:space:]]*}"}"
@@ -198,6 +188,17 @@ ${JUDGES} "${gopts[@]}" update \
     --max-cycles 1 \
     "${options[@]}" \
     "${SELF}/judges/" "${INPUT_FACTBASE}"
+
+for f in yaml xml json html; do
+    ${JUDGES} "${gopts[@]}" print \
+        --format "${f}" \
+        --columns "${INPUT_COLUMNS}" \
+        --highlighted "${INPUT_HIGHLIGHTED}"\
+        --hidden "${INPUT_HIDDEN}" \
+        "${INPUT_FACTBASE}" \
+        "${INPUT_OUTPUT}/${name}.${f}"
+done
+
 ${JUDGES} "${gopts[@]}" print \
     --format xml \
     "${INPUT_FACTBASE}" \


### PR DESCRIPTION
Fixes #817.

Generate YAML, XML, JSON and HTML after `judges update`, so downloads contain the same updated factbase used to render vitals. Previously, facts inserted during the run appeared in the rendered page but were absent from all four downloads.

Adds an entry-point regression using the existing `latest-assessment` judge. The test runs the real entry script and checks that the inserted fact appears in every exported format. It fails on the original script and passes with the export loop moved. Export options are preserved.

Validation: the full entry-point regression passes, including rendering; ShellCheck and Bash syntax checks pass. Full local checks pass: 35 Ruby tests / 81 assertions (one existing generated-SVG check skipped), 100% Ruby coverage, all 22 judge fixtures and RuboCop. All 16 GitHub checks passed, including the full make target and Docker build.
