### PR TITLE
Refresh latest assessment within a transaction

### DIFF
--- a/judges/latest-assessment/latest-assessment.rb
+++ b/judges/latest-assessment/latest-assessment.rb
@@ -5,15 +5,14 @@
 
 require 'fbe/fb'
 
-assessments = Fbe.fb.query('(and (eq what "assessment") (exists text) (exists when))').each.to_a
-return if assessments.empty?
-
-latest = assessments.max_by(&:when)
-
-Fbe.fb.query('(eq what "latest-assessment")').delete!
-
-f = Fbe.fb.insert
-f.what = 'latest-assessment'
-f.text = latest.text
-f.when = latest.when
-f.total = assessments.size
+Fbe.fb.txn do |fb|
+  assessments = fb.query('(and (eq what "assessment") (exists text) (exists when))').each.to_a
+  next if assessments.empty?
+  latest = assessments.max_by(&:when)
+  fb.query('(eq what "latest-assessment")').delete!
+  f = fb.insert
+  f.what = 'latest-assessment'
+  f.text = latest.text
+  f.when = latest.when
+  f.total = assessments.size
+end

--- a/test/pages/test_latest_assessment.rb
+++ b/test/pages/test_latest_assessment.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'factbase/rules'
+require_relative '../test__helper'
+
+class TestLatestAssessment < Minitest::Test
+  def test_preserves_factbase_when_replacement_is_rejected
+    fb = assessment_factbase
+    before = fb.export
+    guarded = Factbase::Rules.new(fb, '(not (eq text "Fresh assessment"))')
+    error = assert_raises(ArgumentError) { load_it('latest-assessment', guarded) }
+    assert_includes(error.message, "doesn't match")
+    assert_equal(before, fb.export)
+  end
+
+  def test_replaces_previous_summary
+    fb = assessment_factbase
+    load_it('latest-assessment', fb)
+    latest = fb.query('(eq what "latest-assessment")').each.to_a
+    assert_equal(1, latest.size)
+    assert_equal('Fresh assessment', latest.first.text)
+    assert_equal(Time.utc(2024, 7, 2), latest.first.when)
+    assert_equal(1, latest.first.total)
+  end
+
+  def test_keeps_factbase_without_source_assessments
+    fb = assessment_factbase
+    fb.query('(eq what "assessment")').delete!
+    before = fb.export
+    load_it('latest-assessment', fb)
+    assert_equal(before, fb.export)
+  end
+
+  private
+
+  def assessment_factbase
+    fb = Factbase.new
+    prior = fb.insert
+    prior.what = 'latest-assessment'
+    prior.text = 'Previous assessment'
+    prior.when = Time.utc(2024, 7, 1)
+    prior.total = 1
+    source = fb.insert
+    source.what = 'assessment'
+    source.text = 'Fresh assessment'
+    source.when = Time.utc(2024, 7, 2)
+    fb
+  end
+end


### PR DESCRIPTION
Fixes #820.

Refresh the latest assessment inside a Factbase transaction. Previously, a failed replacement could leave the old summary deleted and a partial new fact behind. The source lookup, deletion and replacement now commit together, using the existing Factbase transaction support.

Adds a regression with real Factbase validation rules rejecting the replacement. It fails before the fix and verifies the entire exported factbase is unchanged afterward. Successful replacement and the absence of source assessments are covered too.

Validation: all three focused tests pass. Full local checks pass: 38 Ruby tests / 84 assertions, 100% Ruby coverage, all 22 judge fixtures and clean RuboCop. Two existing generated-artifact checks skip locally. All 16 GitHub checks passed, including full make and Docker integration.
