### PR TITLE
Use the report URL in Open Graph metadata

### DIFF
--- a/entries/vitals-contains-open-graph-tags.sh
+++ b/entries/vitals-contains-open-graph-tags.sh
@@ -8,20 +8,22 @@ SELF=$1
 
 BUNDLE_GEMFILE="${SELF}/Gemfile"
 export BUNDLE_GEMFILE
-bundle exec judges eval test.fb "\$fb.insert" > /dev/null
+bundle exec judges eval project.fb "\$fb.insert" > /dev/null
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'GITHUB_REPOSITORY=foo/bar' \
   'GITHUB_REPOSITORY_OWNER=foo' \
-  'INPUT_FACTBASE=test.fb' \
+  'INPUT_URL=https://example.com/reports' \
+  'INPUT_FACTBASE=project.fb' \
   'INPUT_OUTPUT=output' \
   'INPUT_VERBOSE=false' \
   'INPUT_ADLESS=false' \
   'INPUT_GITHUB-TOKEN=THETOKEN' \
   "${SELF}/entry.sh" 2>&1 | tee log.txt
 
-grep 'meta property="og:title"' 'output/test-vitals.html'
-grep 'meta property="og:url"' 'output/test-vitals.html'
-grep 'meta property="og:image"' 'output/test-vitals.html'
-grep 'meta property="og:type"' 'output/test-vitals.html'
-grep 'meta property="og:description"' 'output/test-vitals.html'
+grep 'meta property="og:title"' 'output/project-vitals.html'
+grep 'meta property="og:url" content="https://example.com/reports/project-vitals.html"' 'output/project-vitals.html'
+grep -F '[![discipline](https://example.com/reports/project-badge.svg)](https://example.com/reports/project-vitals.html)' 'output/project-vitals.html'
+grep 'meta property="og:image"' 'output/project-vitals.html'
+grep 'meta property="og:type"' 'output/project-vitals.html'
+grep 'meta property="og:description"' 'output/project-vitals.html'

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -172,11 +172,7 @@
           </xsl:attribute>
         </meta>
         <meta property="og:type" content="website"/>
-        <meta property="og:url">
-          <xsl:attribute name="content">
-            <xsl:value-of select="$url"/>
-          </xsl:attribute>
-        </meta>
+        <meta property="og:url" content="{$url}/{$name}-vitals.html"/>
         <xsl:if test="$adless = 'false'">
           <meta property="og:image" content="https://www.zerocracy.com/og/vitals.png"/>
           <meta property="og:image:type" content="image/png"/>


### PR DESCRIPTION
Fixes #829.

Build the Open Graph URL from the report directory and factbase name, so a project report points to `https://example.com/reports/project-vitals.html`. Keep the base URL available for badge links.

The entry-point regression uses a custom URL and `project.fb`, checks the exact metadata URL, and verifies the badge Markdown. It fails on the original transform and passes with this fix.

Validation: the full local Ruby suite and judge fixtures pass, RuboCop is clean, and the modified entry script passes Bash syntax validation. Full Make/Docker validation will run in CI.
