### PR TITLE
Keep metric colors stable across fact import order

### DIFF
--- a/test/pages/test_qo_section.rb
+++ b/test/pages/test_qo_section.rb
@@ -7,6 +7,31 @@ require 'English'
 require_relative '../test__helper'
 
 class TestQoSection < Minitest::Test
+  def test_metric_colors_do_not_depend_on_fact_order
+    facts = [
+      '<f><when>2024-07-03T22:22:22Z</when><what>quality-of-service</what>' \
+      '<n_alpha>0.1</n_alpha><n_beta>0.2</n_beta><n_composite>0.5</n_composite></f>',
+      '<f><when>2024-06-23T22:22:22Z</when><what>quality-of-service</what>' \
+      '<n_beta>0.3</n_beta><n_alpha>0.4</n_alpha><n_composite>0.8</n_composite></f>'
+    ]
+    colors =
+      [facts, facts.reverse].map do |order|
+        xml = xslt(
+          "<r><xsl:call-template name='qo-section'>" \
+          "<xsl:with-param name='what' select=\"'quality-of-service'\"/>" \
+          "<xsl:with-param name='title' select=\"'QoS'\"/>" \
+          '</xsl:call-template></r>',
+          "<fb>#{order.join}</fb>",
+          'today' => '2024-09-26T04:04:04Z'
+        )
+        script = xml.xpath('//script').map(&:content).join
+        script.scan(/label:'([^']+)',borderColor:([^,]+)/).to_h
+      end
+    assert_equal(%w[Alpha Beta Composite], colors.first.keys.sort)
+    assert_equal("'orange'", colors.first['Composite'])
+    assert_equal(colors.first, colors.last, 'Import order must not change metric colors')
+  end
+
   def test_snake_case_to_title
     xml = xslt(
       '<r><xsl:value-of select="z:snake-case-to-title(\'average_issue_lifetime\')"/></r>',

--- a/xsl/qo-section.xsl
+++ b/xsl/qo-section.xsl
@@ -81,6 +81,7 @@
           <xsl:text>],</xsl:text>
           <xsl:text>datasets:[</xsl:text>
           <xsl:for-each select="distinct-values($facts/f/*[starts-with(name(), 'n_')]/name())">
+            <xsl:sort select="."/>
             <xsl:variable name="n" select="."/>
             <xsl:if test="position() &gt; 1">
               <xsl:text>,</xsl:text>


### PR DESCRIPTION
Fixes #827.

Sort metric names before assigning fallback colors. Reports containing the same metrics now keep the same color assignments when facts are imported in a different order; explicit colors remain unchanged.

The regression renders the same two complete facts in both import orders and compares every emitted metric color, including the explicit orange composite. It fails on the original transform because Alpha and Beta swap colors. This uses the sorting option requested in the issue; adding a new metric can still change positional fallback colors.

Validation: 36 Ruby tests and 78 assertions pass (2 existing generated-artifact skips); all 22 judge fixtures pass. RuboCop passes after its requested test-layout correction, and the regression passes again on the final source. Full Make/Docker validation runs in CI.
