### PR TITLE
Distinguish badge and running award reporting periods

### DIFF
--- a/test/pages/test_badge.rb
+++ b/test/pages/test_badge.rb
@@ -46,6 +46,12 @@ class TestBadge < Minitest::Test
     assert_includes(texts, '+4.0', xml)
   end
 
+  def test_labels_the_fixed_reporting_period
+    xml = badge_svg('<fb/>')
+    assert_includes(xml.xpath("//*[local-name()='text']").map(&:text), 'avg/256d')
+    assert_includes(xml.xpath("//*[local-name()='title']").text, '256 days')
+  end
+
   private
 
   def badge_svg(xml)

--- a/test/pages/test_vitals.rb
+++ b/test/pages/test_vitals.rb
@@ -142,14 +142,37 @@ class TestVitals < Minitest::Test
     refute_match(/zerocracy/i, html[%r{<meta name="description".*?/>}m].to_s, html)
   end
 
+  def test_explains_both_award_windows
+    facts = <<~XML
+      <fb>
+        <f><what>pmp</what><area>hr</area><days_of_running_balance>28</days_of_running_balance></f>
+        <f>
+          <when>2024-09-20T00:00:00Z</when><award>10</award>
+          <who>1</who><who_name>recent</who_name><is_human>1</is_human>
+        </f>
+        <f>
+          <when>2024-06-18T00:00:00Z</when><award>90</award>
+          <who>2</who><who_name>older</who_name><is_human>1</is_human>
+        </f>
+      </fb>
+    XML
+    html = Nokogiri::HTML(generate_vitals_html(xml: facts))
+    refute_nil(html.at_css('#award-windows'), 'Both reporting windows must be visible')
+    summary = html.at_css('#award-windows').text.gsub(/\s+/, ' ').strip
+    assert_includes(summary, '256 days, all recorded awards: +100.0 points total, +50.0 per award')
+    assert_includes(summary, '28 days, human awards: +10.0 points total')
+    assert_includes(html.at_css('meta[name="description"]')['content'], 'Reporting period: 256 days.')
+    assert_includes(html.at_css('meta[property="og:description"]')['content'], 'Reporting period: 256 days.')
+  end
+
   private
 
-  def generate_vitals_html(adless: 'false')
+  def generate_vitals_html(adless: 'false', xml: nil)
     saxon = File.join(__dir__, '../../target/saxon.jar')
     skip("Saxon not built at #{saxon}") unless File.exist?(saxon)
     Dir.mktmpdir do |dir|
       input = File.join(dir, 'input.xml')
-      File.write(input, <<~XML)
+      File.write(input, xml || <<~XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <fb>
           <f>

--- a/xsl/badge.xsl
+++ b/xsl/badge.xsl
@@ -25,7 +25,7 @@
     <xsl:variable name="badgeHeight" select="20"/>
     <xsl:variable name="logoWidth" select="20"/>
     <xsl:variable name="fontSize" select="11"/>
-    <xsl:variable name="leftWidth" select="50"/>
+    <xsl:variable name="leftWidth" select="88"/>
     <xsl:variable name="rightWidth">
       <xsl:choose>
         <xsl:when test="abs($avg) &gt; 99">
@@ -41,6 +41,8 @@
     </xsl:variable>
     <xsl:variable name="width" select="$leftWidth + $rightWidth"/>
     <svg width="{$width}" height="{$badgeHeight}">
+      <title>Average award over 256 days</title>
+      <desc>The fixed badge period is independent of the configured running balance period.</desc>
       <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -87,8 +89,8 @@
         </xsl:choose>
       </xsl:variable>
       <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="{$fontSize}">
-        <text x="{$logoWidth + ($leftWidth - $logoWidth) div 2}" y="{$badgeHeight - $fontSize div 2}" fill="#010101" fill-opacity=".3" text-anchor="middle">avg</text>
-        <text x="{$logoWidth + ($leftWidth - $logoWidth) div 2}" y="{$badgeHeight - $fontSize div 2 - 1}" text-anchor="middle">avg</text>
+        <text x="{$logoWidth + ($leftWidth - $logoWidth) div 2}" y="{$badgeHeight - $fontSize div 2}" fill="#010101" fill-opacity=".3" text-anchor="middle">avg/256d</text>
+        <text x="{$logoWidth + ($leftWidth - $logoWidth) div 2}" y="{$badgeHeight - $fontSize div 2 - 1}" text-anchor="middle">avg/256d</text>
         <text x="{$leftWidth + $rightWidth div 2}" y="{$badgeHeight - $fontSize div 2}" fill="#010101" fill-opacity=".3" text-anchor="middle">
           <xsl:value-of select="$n"/>
         </text>

--- a/xsl/vitals.xsl
+++ b/xsl/vitals.xsl
@@ -137,6 +137,9 @@
     </xsl:for-each>
   </xsl:template>
   <xsl:template match="/">
+    <xsl:variable name="summary-facts" select="$fb/f[z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award]"/>
+    <xsl:variable name="summary-count" select="count($summary-facts)" as="xs:integer"/>
+    <xsl:variable name="summary-average" as="xs:double" select="if ($summary-count = 0) then xs:double('0') else sum($summary-facts/award) div $summary-count"/>
     <xsl:text disable-output-escaping="yes">&lt;!DOCTYPE html&gt;</xsl:text>
     <html lang="en">
       <xsl:attribute name="class">
@@ -146,9 +149,6 @@
         <meta charset="UTF-8"/>
         <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
         <xsl:variable name="description">
-          <xsl:variable name="facts" select="$fb/f[z:when(when) &gt; (xs:dateTime($today) - xs:dayTimeDuration('P256D')) and award]"/>
-          <xsl:variable name="count" select="count($facts)" as="xs:integer"/>
-          <xsl:variable name="avg" as="xs:double" select="if ($count = 0) then xs:double('0') else sum($facts/award) div $count"/>
           <xsl:text>The "</xsl:text>
           <xsl:value-of select="$name"/>
           <xsl:text>" product</xsl:text>
@@ -156,12 +156,12 @@
             <xsl:text> is supervised by Zerocracy</xsl:text>
           </xsl:if>
           <xsl:text>: </xsl:text>
-          <xsl:value-of select="z:format-signed($avg, '0.0')"/>
+          <xsl:value-of select="z:format-signed($summary-average, '0.0')"/>
           <xsl:text> average points per task, </xsl:text>
-          <xsl:value-of select="format-number(sum($facts/award), '0')"/>
+          <xsl:value-of select="format-number(sum($summary-facts/award), '0')"/>
           <xsl:text> total points earned, </xsl:text>
-          <xsl:value-of select="count(distinct-values($facts/who_name))"/>
-          <xsl:text> contributors.</xsl:text>
+          <xsl:value-of select="count(distinct-values($summary-facts/who_name))"/>
+          <xsl:text> contributors. Reporting period: 256 days.</xsl:text>
         </xsl:variable>
         <meta name="description" content="{$description}"/>
         <meta property="og:title">
@@ -236,6 +236,17 @@
             </xsl:if>
           </header>
           <article>
+            <p id="award-windows" class="smaller">
+              <xsl:text>Badge and summary — 256 days, all recorded awards: </xsl:text>
+              <xsl:value-of select="z:format-signed(sum($summary-facts/award), '0.0')"/>
+              <xsl:text> points total, </xsl:text>
+              <xsl:value-of select="z:format-signed($summary-average, '0.0')"/>
+              <xsl:text> per award. Running table — </xsl:text>
+              <xsl:value-of select="$days"/>
+              <xsl:text> days, human awards: </xsl:text>
+              <xsl:value-of select="z:format-signed(sum($facts/award), '0.0')"/>
+              <xsl:text> points total.</xsl:text>
+            </p>
             <xsl:apply-templates select="/" mode="awards"/>
             <xsl:apply-templates select="/" mode="assessment"/>
             <xsl:apply-templates select="/" mode="repositories"/>
@@ -380,7 +391,7 @@
               <xsl:text>You can use this badge in the </xsl:text>
               <code>README.md</code>
               <xsl:text> file of your GitHub repositories. </xsl:text>
-              <xsl:text>It shows the average reward amount. </xsl:text>
+              <xsl:text>It shows the average reward amount over 256 days, independently of the running table period. </xsl:text>
               <br/>
               <xsl:text>The higher the number, the better the discipline you maintain. </xsl:text>
               <xsl:text>Click </xsl:text>


### PR DESCRIPTION
Fixes #825 using the requested alternative of labeling both reporting windows.

Preserve the 256-day badge calculation introduced in #417. The badge now says `avg/256d`, its title explains the period, and HTML/Open Graph descriptions name it. A visible comparison shows the long-window total and average beside the configured running-table period and human-award total.

A real-render fixture with a recent 10-point award and an older 90-point award shows 100 points and a 50-point average over 256 days, versus 10 human-award points over 28 days. The regression fails on the original transform and passes with this change. Existing calculations and population filters are preserved.

Validation: full Ruby tests pass (37 tests, 87 assertions, 2 existing skips), all 22 judge fixtures pass, and RuboCop passes after test layout cleanup. The final regression adds an explicit presence assertion and passes with 9 assertions. Rendered text and badge checked at normal and 360px widths in an isolated fixture; full Make/Docker validation runs in CI.
