### PR TITLE
Reject queries and fragments in the report base URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,6 @@ inputs:
     required: false
     default: 5
   url:
-    description: 'The URL where the static files will be visible'
+    description: 'The URL where the static files will be visible, without a query or fragment'
     required: false
     default: ''

--- a/entries/rejects-url-query-or-fragment.sh
+++ b/entries/rejects-url-query-or-fragment.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+# A version-only judge exposes accidental processing of an invalid URL.
+cat > judges-probe <<'PROBE'
+#!/usr/bin/env bash
+if [ "$1" = '--version' ]; then
+    echo 'judges probe'
+    exit 0
+fi
+echo 'Unexpected factbase processing' >&2
+exit 42
+PROBE
+chmod +x judges-probe
+touch test.fb
+
+for url in 'https://example.com/reports?theme=dark' 'https://example.com/reports#top' 'https://example.com/reports?' 'https://example.com/reports#'; do
+    if env "GITHUB_WORKSPACE=${PWD}" "JUDGES=${PWD}/judges-probe" \
+        'LATEST_VERSION=test' 'INPUT_FACTBASE=test.fb' \
+        'INPUT_OUTPUT=output' "INPUT_URL=${url}" \
+        "${SELF}/entry.sh" > log.txt 2>&1; then
+        echo "Expected invalid URL to fail: ${url}"
+        exit 1
+    fi
+    grep -F 'INPUT_URL must not contain a query or fragment' log.txt
+    [ ! -e output ]
+    if grep -F 'Unexpected factbase processing' log.txt; then
+        exit 1
+    fi
+done

--- a/entry.sh
+++ b/entry.sh
@@ -58,6 +58,13 @@ if [ -z "${GITHUB_WORKSPACE}" ]; then
     exit 1
 fi
 cd "${GITHUB_WORKSPACE}"
+
+case "${INPUT_URL}" in
+    *\?*|*\#*)
+        echo 'INPUT_URL must not contain a query or fragment' >&2
+        exit 1
+        ;;
+esac
 echo "The workspace directory is: $(pwd)"
 
 if [ -z "${INPUT_FACTBASE}" ]; then


### PR DESCRIPTION
Fixes #831 using the requested validation alternative.

Reject a custom `url` containing a query or fragment before creating output or processing the factbase. Previously, `https://example.com/reports?theme=dark` produced links with the report filename inside the query. Document the input restriction in the action metadata.

The new entry regression covers populated and empty query/fragment delimiters, verifies the diagnostic, and checks that neither output creation nor factbase processing occurs. It fails on the unchanged base and passes with this change. The existing full custom-URL render also passes. Local `bundle exec rake`, ShellCheck, and Bash syntax checks pass; full make/Docker validation will run in CI.
