### PR TITLE
Rebuild report output when minifier configuration changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ assets: $(XSLS) $(JS) $(CSS)
 target/xsl/%.xsl: xsl/%.xsl | target/xsl
 	cp "$<" "$@"
 
-target/output/%: target/fb/%.fb entry.sh Makefile $(XSLS) $(CSS) $(JS_TEST) $(SAXON) | target/html
+target/output/%: target/fb/%.fb entry.sh html-minifier-config.json Makefile $(XSLS) $(CSS) $(JS_TEST) $(SAXON) | target/html
 	export INPUT_VERBOSE=yes
 	export INPUT_OPTIONS=testing=yes
 	export GITHUB_WORKSPACE=.

--- a/test/pages/test_makefile.rb
+++ b/test/pages/test_makefile.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fileutils'
+require 'tmpdir'
+require_relative '../test__helper'
+
+class TestMakefile < Minitest::Test
+  def test_regenerates_output_when_minifier_configuration_changes
+    Dir.mktmpdir do |dir|
+      FileUtils.cp(File.join(__dir__, '../../Makefile'), dir)
+      FileUtils.mkdir_p(%w[target/fb target/css target/js tests sass js].map { |path| File.join(dir, path) })
+      %w[
+        target/fb/sample.fb tests/sample.yml target/css/main.css target/js/test.js
+        target/saxon.jar sass/main.scss js/main.js tests/symbols.js
+      ].each do |file|
+        File.write(File.join(dir, file), '')
+      end
+      File.write("#{dir}/html-minifier-config.json", '{"collapseWhitespace":false}')
+      File.write(
+        "#{dir}/entry.sh",
+        <<~SH
+          #!/usr/bin/env bash
+          set -e
+          mkdir -p "${INPUT_OUTPUT}"
+          cp html-minifier-config.json "${INPUT_OUTPUT}/used-config.json"
+        SH
+      )
+      FileUtils.chmod(0o755, "#{dir}/entry.sh")
+      before = Time.now - 120
+      Dir.glob("#{dir}/**/*").select { |file| File.file?(file) }.each do |file|
+        File.utime(before, before, file)
+      end
+      command = [
+        'make', '-C', dir, 'target/output/sample', 'XSLS=',
+        '-o', 'target/css/main.css', '-o', 'target/js/test.js', '-o', 'target/saxon.jar',
+        '-o', 'stylelint', '-o', 'target/js/main.js'
+      ]
+      qbash(command, stdout: fake_loog)
+      output = "#{dir}/target/output/sample"
+      assert_equal('{"collapseWhitespace":false}', File.read("#{output}/used-config.json"))
+      File.utime(before + 30, before + 30, output)
+      File.write("#{dir}/html-minifier-config.json", '{"collapseWhitespace":true}')
+      File.utime(before + 60, before + 60, "#{dir}/html-minifier-config.json")
+      qbash(command, stdout: fake_loog)
+      assert_equal('{"collapseWhitespace":true}', File.read("#{output}/used-config.json"))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #819.

Add `html-minifier-config.json` to the report output prerequisites so changing minifier settings rebuilds existing output. Previously an incremental build could retain HTML produced with the old configuration.

The regression runs the real Makefile twice in an isolated fixture. A small entry-point probe records the configuration used; unrelated asset generation is held fixed. After changing only the minifier configuration, the original Makefile keeps the old result and the patched Makefile regenerates it. Timestamps are set explicitly without sleeps. `action.yml` is not read by this local Makefile recipe, so it is not added as a dependency.

Validation: regression fails before the fix and passes after it. Full local `bundle exec rake` passes, including judge fixtures and Ruby lint. Full make/Docker runs in CI.
