### PR TITLE
Rerun HTML validation when fixture assertions change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ target/output/%: target/fb/%.fb entry.sh Makefile $(XSLS) $(CSS) $(JS_TEST) $(SA
 	export INPUT_OUTPUT=target/output/$${fb}
 	./entry.sh
 
-target/html/%.html: target/output/%
+target/html/%.html: target/output/% tests/%.yml
 	n=$$(basename "$@")
 	n=$${n%.*}
 	cp "$$(dirname "$<")/$${n}/$${n}.html" "$$(dirname "$@")/$${n}.html"

--- a/test/pages/test_makefile_validation.rb
+++ b/test/pages/test_makefile_validation.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+require_relative '../test__helper'
+
+class TestMakefileValidation < Minitest::Test
+  def test_reruns_changed_xpath_even_when_output_directory_timestamp_is_unchanged
+    Dir.mktmpdir do |dir|
+      FileUtils.cp(File.join(__dir__, '../../Makefile'), dir)
+      FileUtils.mkdir_p(%w[target/fb target/css target/js tests sass js].map { |path| File.join(dir, path) })
+      %w[
+        target/fb/sample.fb target/css/main.css target/js/test.js target/saxon.jar
+        sass/main.scss js/main.js tests/symbols.js
+      ].each do |file|
+        File.write(File.join(dir, file), '')
+      end
+      File.write("#{dir}/tests/sample.yml", "- xpaths: /html/body/p\n")
+      File.write("#{dir}/judges-probe", "#!/usr/bin/env bash\ntouch \"${@: -1}\"\n")
+      File.write(
+        "#{dir}/entry.sh",
+        <<~SH
+          #!/usr/bin/env bash
+          set -e
+          mkdir -p "${INPUT_OUTPUT}"
+          for name in sample sample-vitals; do
+              echo '<!DOCTYPE html><html><head><title>Probe</title></head><body><p>ok</p></body></html>' > "${INPUT_OUTPUT}/${name}.html"
+          done
+        SH
+      )
+      %w[entry.sh judges-probe].each { |file| FileUtils.chmod(0o755, File.join(dir, file)) }
+      before = Time.now - 120
+      Dir.glob("#{dir}/**/*").select { |file| File.file?(file) }.each do |file|
+        File.utime(before, before, file)
+      end
+      command = [
+        'make', '-C', dir, 'target/html/sample.html', 'XSLS=', 'JUDGES=./judges-probe',
+        '-o', 'target/css/main.css', '-o', 'target/js/test.js', '-o', 'target/saxon.jar',
+        '-o', 'stylelint', '-o', 'target/js/main.js'
+      ]
+      stdout, stderr, status = Open3.capture3(*command)
+      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+      {
+        'target/output/sample' => 20, 'target/html/sample.html' => 30,
+        'target/html/sample-vitals.html' => 30, 'target/fb/sample.fb' => 10
+      }.each do |file, offset|
+        File.utime(before + offset, before + offset, File.join(dir, file))
+      end
+      File.write("#{dir}/tests/sample.yml", "- xpaths: /html/body/missing\n")
+      File.utime(before + 60, before + 60, "#{dir}/tests/sample.yml")
+      stdout, stderr, status = Open3.capture3(*command)
+      refute_predicate(status, :success?, "Changed XPath was not checked: #{stdout}\n#{stderr}")
+      assert_includes(stderr, 'XPath set is empty')
+    end
+  end
+end

--- a/test/pages/test_makefile_validation.rb
+++ b/test/pages/test_makefile_validation.rb
@@ -19,6 +19,7 @@ class TestMakefileValidation < Minitest::Test
       ].each do |file|
         File.write(File.join(dir, file), '')
       end
+      File.write("#{dir}/html-minifier-config.json", '{}')
       File.write("#{dir}/tests/sample.yml", "- xpaths: /html/body/p\n")
       File.write("#{dir}/judges-probe", "#!/usr/bin/env bash\ntouch \"${@: -1}\"\n")
       File.write(


### PR DESCRIPTION
Fixes #824.

Add the fixture YAML as a direct prerequisite of the HTML validation target. Changing an XPath already regenerates the factbase and report files, but overwriting files leaves the output directory timestamp unchanged. Make therefore skips the validation recipe and can report success for an invalid new assertion.

The regression runs the real Makefile, YAML parsing and XPath validation in an isolated fixture, with probes for report generation and factbase import. A valid XPath passes initially; changing it to a missing element must fail with `XPath set is empty`. This fails on the original Makefile and passes with the dependency added. Explicit timestamps avoid sleeps.

Focused regression and full local `bundle exec rake` pass, including judge fixtures and Ruby lint. Full make/Docker validation runs in CI.

Also verified together with the pending minifier dependency change in #851: 37 local tests and 83 assertions pass, with two existing generated-artifact skips; all 22 judge fixtures and Ruby lint pass. The validation fixture includes a minifier configuration so the two changes can land in either order.
