### PR TITLE
Refresh factbases after judge and library source changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 .SHELLFLAGS := -x -e -o pipefail -c
 SHELL := bash
 
+SOURCES = $(foreach dir,$(wildcard judges lib),$(shell find $(dir) -type f -name '*.rb'))
 YAMLS = $(wildcard tests/*.yml)
 FBS = $(subst tests/,target/fb/,${YAMLS:.yml=.fb})
 HTMLS = $(subst fb/,html/,${FBS:.fb=.html})
@@ -63,7 +64,7 @@ target/html/%.html: target/output/%
 		fi
 	done
 
-target/fb/%.fb: tests/%.yml Makefile | target/fb
+target/fb/%.fb: tests/%.yml Makefile $(SOURCES) | target/fb
 	if [ -e "$@" ]; then $(JUDGES) trim --query='(always)' "$@"; fi
 	$(JUDGES) import "$<" "$@"
 

--- a/test/pages/test_makefile_sources.rb
+++ b/test/pages/test_makefile_sources.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+require_relative '../test__helper'
+
+class TestMakefileSources < Minitest::Test
+  def test_reruns_judges_after_judge_or_library_source_changes
+    Dir.mktmpdir do |dir|
+      FileUtils.cp(File.join(__dir__, '../../Makefile'), dir)
+      FileUtils.mkdir_p(
+        %w[target/fb target/css target/js tests sass js judges/probe lib/nested].map { |path| File.join(dir, path) }
+      )
+      %w[
+        target/fb/sample.fb tests/sample.yml target/css/main.css target/js/test.js
+        target/saxon.jar sass/main.scss js/main.js tests/symbols.js
+      ].each { |file| File.write(File.join(dir, file), '') }
+      File.write("#{dir}/html-minifier-config.json", '{}')
+      File.write("#{dir}/judges-probe", "#!/usr/bin/env bash\ntouch \"${@: -1}\"\n")
+      File.write("#{dir}/lib/nested/value.rb", "VALUE = 'first'\n")
+      File.write("#{dir}/judges/probe/probe.rb", "require_relative '../../lib/nested/value'\nputs VALUE\n")
+      File.write(
+        "#{dir}/entry.sh",
+        <<~SH
+          #!/usr/bin/env bash
+          set -e
+          mkdir -p "${INPUT_OUTPUT}"
+          ruby judges/probe/probe.rb > "${INPUT_OUTPUT}/result.txt"
+        SH
+      )
+      %w[entry.sh judges-probe].each { |file| FileUtils.chmod(0o755, File.join(dir, file)) }
+      before = Time.now - 120
+      Dir.glob("#{dir}/**/*").select { |file| File.file?(file) }.each do |file|
+        File.utime(before, before, file)
+      end
+      command = [
+        'make', '-C', dir, 'target/output/sample', 'XSLS=', 'JUDGES=./judges-probe',
+        '-o', 'target/css/main.css', '-o', 'target/js/test.js', '-o', 'target/saxon.jar',
+        '-o', 'stylelint', '-o', 'target/js/main.js'
+      ]
+      stdout, stderr, status = Open3.capture3(*command)
+      assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+      assert_equal("first\n", File.read("#{dir}/target/output/sample/result.txt"))
+      [
+        ['judges/probe/probe.rb', "require_relative '../../lib/nested/value'\nputs VALUE.upcase\n", "FIRST\n"],
+        ['lib/nested/value.rb', "VALUE = 'second'\n", "SECOND\n"]
+      ].each do |file, source, expected|
+        File.utime(before + 10, before + 10, "#{dir}/target/fb/sample.fb")
+        File.utime(before + 30, before + 30, "#{dir}/target/output/sample")
+        File.write(File.join(dir, file), source)
+        File.utime(before + 60, before + 60, File.join(dir, file))
+        stdout, stderr, status = Open3.capture3(*command)
+        assert_predicate(status, :success?, "#{stdout}\n#{stderr}")
+        assert_equal(expected, File.read("#{dir}/target/output/sample/result.txt"), file)
+        File.utime(before, before, File.join(dir, file))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #818.

Make generated factbases depend on Ruby sources under `judges/` and `lib/`, including nested directories. Editing a judge or supporting library now refreshes the factbase and reruns report generation during an incremental build.

The regression runs the real Makefile in an isolated fixture with a small Ruby judge and nested library. It verifies that changing the judge changes the result, then that changing only the library changes it again. Factbase import and report rendering are controlled probes; unrelated asset generation is held fixed. The original Makefile retains the old result, while the patched version reruns the changed source. Explicit timestamps avoid sleeps.

The focused regression and full local suite pass: 36 tests, 84 assertions, 22 judge fixtures, and Ruby lint. Combined with pending #851 and #852, 38 tests and 92 assertions pass. Both suites have two existing generated-artifact skips. Full make/Docker runs in CI.
