### PR TITLE
#841: ignore an empty github_token option

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -125,6 +125,10 @@ while IFS= read -r o; do
         continue
     fi
     if [[ "${v}" == "github_token="* ]]; then
+        if [ "${v}" = "github_token=" ]; then
+            echo "The 'github_token' option is empty, ignoring it"
+            continue
+        fi
         if [ "${INPUT_VERBOSE}" == 'true' ]; then
             set +x
         fi


### PR DESCRIPTION
Fixes #841.

`github_token=` with no value counted as "the token option is set", so the fallback that copies `INPUT_GITHUB-TOKEN` into the options never ran and every judge went to the GitHub API unauthenticated, while the log claimed the token was in place.

An empty value is now dropped where the options are built, with a line saying so, and the fallback fills in the action token as it does when the option is absent. A real token is untouched, including the masking.

Checked by running that part of the script on its own with `INPUT_OPTIONS='github_token='`: before, the options end up as `--option=github_token=`; after, as `--option=github_token=<the action token>`. I did not add a test, since `entry.sh` is only exercised through the Docker run in `make entry` and there is no harness for a case like this; happy to add one if you would like it wired in there.
