### PR TITLE
#830: take only a file as the auto-detected factbase

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -62,8 +62,13 @@ echo "The workspace directory is: $(pwd)"
 
 if [ -z "${INPUT_FACTBASE}" ]; then
     echo "No factbase parameter provided, looking for *.fb files in current directory..."
-    fb_files=(*.fb)
-    if [ "${fb_files[0]}" = "*.fb" ]; then
+    fb_files=()
+    for candidate in *.fb; do
+        if [ -f "${candidate}" ]; then
+            fb_files+=("${candidate}")
+        fi
+    done
+    if [ ${#fb_files[@]} -eq 0 ]; then
         echo "ERROR: No .fb files found in the current directory."
         echo "Please provide a factbase parameter or ensure there is exactly one .fb file in the directory."
         exit 1
@@ -81,7 +86,7 @@ if [ -z "${INPUT_FACTBASE}" ]; then
 else
     echo "Using provided factbase: ${INPUT_FACTBASE}"
     if [ ! -f "${INPUT_FACTBASE}" ]; then
-        echo "ERROR: The factbase file '${INPUT_FACTBASE}' does not exist."
+        echo "ERROR: The factbase '${INPUT_FACTBASE}' is not a file."
         exit 1
     fi
 fi


### PR DESCRIPTION
Fixes #830.

The auto-detection took the first `*.fb` glob match without asking whether it is a file, so a stale `cache.fb/` directory was announced as the factbase and the run died much later inside `judges` with an import error that says nothing about the real problem.

The glob is now filtered to regular files, so a workspace that holds only such a directory gets the same clear "No .fb files found" message as an empty one, and a directory sitting next to a real factbase is simply skipped. The explicit-path branch already used `-f`; its message now says "is not a file" rather than "does not exist", which is what actually failed.

Checked by running that block on its own in a directory that holds only `cache.fb/`: before, it announces `Auto-detected factbase: cache.fb`; after, it exits 1 with the proper diagnostic, and it still picks `real.fb` when one is there. I did not add a test, since `entry.sh` is only exercised through the Docker run in `make entry`; tell me if you want a case wired in there.
